### PR TITLE
Syntax highlighting

### DIFF
--- a/playground/public/haskell_config.json
+++ b/playground/public/haskell_config.json
@@ -1,0 +1,29 @@
+{
+    "comments": {
+        "lineComment": "--",
+        "blockComment": ["{-", "-}"]
+    },
+    "brackets": [
+       ["{", "}"],
+       ["[", "]"],
+       ["(", ")"]
+   ],
+   "autoClosingPairs": [
+       { "open": "{", "close": "}" },
+       { "open": "[", "close": "]" },
+       { "open": "(", "close": ")" },
+       { "open": "\"", "close": "\"", "notIn": ["string"] },
+       { "open": "`", "close": "`", "notIn": ["string", "comment"] }
+   ],
+   "surroundingPairs": [
+       ["{", "}"],
+       ["[", "]"],
+       ["(", ")"],
+       ["'", "'"],
+       ["\"", "\""],
+       ["`", "`"]
+   ],
+   "folding": {
+       "offSide": true
+   }
+}

--- a/playground/public/haskell_grammar.json
+++ b/playground/public/haskell_grammar.json
@@ -1,0 +1,2526 @@
+{
+    "fileTypes": [
+      "hs",
+      "hs-boot",
+      "hsig"
+    ],
+    "keyEquivalent": "^~H",
+    "name": "Haskell",
+    "patterns": [
+      {
+        "include": "#liquid_haskell"
+      },
+      {
+        "include": "#comment_like"
+      },
+      {
+        "include": "#numeric_literals"
+      },
+      {
+        "include": "#string_literal"
+      },
+      {
+        "include": "#char_literal"
+      },
+      {
+        "match": "(?<!@|#)-\\}",
+        "name": "invalid"
+      },
+      {
+        "match": "(\\()\\s*(\\))",
+        "name": "constant.language.unit.haskell",
+        "captures": {
+          "1": {
+            "name": "punctuation.paren.haskell"
+          },
+          "2": {
+            "name": "punctuation.paren.haskell"
+          }
+        }
+      },
+      {
+        "match": "(\\()(#)\\s*(#)(\\))",
+        "name": "constant.language.unit.unboxed.haskell",
+        "captures": {
+          "1": {
+            "name": "punctuation.paren.haskell"
+          },
+          "2": {
+            "name": "keyword.operator.hash.haskell"
+          },
+          "3": {
+            "name": "keyword.operator.hash.haskell"
+          },
+          "4": {
+            "name": "punctuation.paren.haskell"
+          }
+        }
+      },
+      {
+        "match": "(\\()\\s*,[\\s,]*(\\))",
+        "name": "support.constant.tuple.haskell",
+        "captures": {
+          "1": {
+            "name": "punctuation.paren.haskell"
+          },
+          "2": {
+            "name": "punctuation.paren.haskell"
+          }
+        }
+      },
+      {
+        "match": "(\\()(#)\\s*,[\\s,]*(#)(\\))",
+        "name": "support.constant.tuple.unboxed.haskell",
+        "captures": {
+          "1": {
+            "name": "punctuation.paren.haskell"
+          },
+          "2": {
+            "name": "keyword.operator.hash.haskell"
+          },
+          "3": {
+            "name": "keyword.operator.hash.haskell"
+          },
+          "4": {
+            "name": "punctuation.paren.haskell"
+          }
+        }
+      },
+      {
+        "match": "(\\[)\\s*(\\])",
+        "name": "constant.language.empty-list.haskell",
+        "captures": {
+          "1": {
+            "name": "punctuation.bracket.haskell"
+          },
+          "2": {
+            "name": "punctuation.bracket.haskell"
+          }
+        }
+      },
+      {
+        "begin": "(\\b(?<!')(module)|^(signature))(\\b(?!'))",
+        "beginCaptures": {
+          "2": {
+            "name": "keyword.other.module.haskell"
+          },
+          "3": {
+            "name": "keyword.other.signature.haskell"
+          }
+        },
+        "end": "(?=\\b(?<!')where\\b(?!'))",
+        "name": "meta.declaration.module.haskell",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "include": "#module_name"
+          },
+          {
+            "include": "#module_exports"
+          },
+          {
+            "match": "[a-z]+",
+            "name": "invalid"
+          }
+        ]
+      },
+      {
+        "include": "#ffi"
+      },
+      {
+        "begin": "^(\\s*)(class)(\\b(?!'))",
+        "beginCaptures": {
+          "2": {
+            "name": "keyword.other.class.haskell"
+          }
+        },
+        "end": "(?x) # Detect end of class declaration:\n         # 'where' keyword\n   (?=(?<!')\\bwhere\\b(?!'))  \n         # Decreasing indentation\n   |(?=\\}|;)      # Explicit indentation\n   |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n       \\1\\s+\\S    # - more indented, or\n     | \\s*        # - starts with whitespace, followed by:\n       (?: $      #   - the end of the line (i.e. empty line), or\n       |\\{-[^@]   #   - the start of a block comment, or\n       |--+       #   - the start of a single-line comment.\n          (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                  # The double dash may not be followed by other operator characters\n                  # (then it would be an operator, not a comment)\n     )",
+        "name": "meta.declaration.class.haskell",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "include": "#where"
+          },
+          {
+            "include": "#type_signature"
+          }
+        ]
+      },
+      {
+        "begin": "(?x)\n  ^(\\s*)(data|newtype)(?:\\s+(instance))?\\s+\n  # Keep consuming characters until:\n  ((?:(?!\n  # the equals symbol or the start of a single-line comment, or\n    (?: \n      (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]) # non-symbol\n      (?:=|--+)\n      (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])  # non-symbol\n    )\n  # the \"where\" or \"deriving\" keywords, or\n  | (?:\\b(?<!')(?:where|deriving)\\b(?!'))\n  # the start of a block comment.\n  | {-\n  #\n  ).)*)\n  (?=\\b(?<!'')where\\b(?!''))",
+        "beginCaptures": {
+          "2": {
+            "name": "keyword.other.$2.haskell"
+          },
+          "3": {
+            "name": "keyword.other.instance.haskell"
+          },
+          "4": {
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ]
+          }
+        },
+        "name": "meta.declaration.$2.generalized.haskell",
+        "end": "(?x) # Detect end of data declaration:\n         # Deriving clause\n   (?=(?<!')\\bderiving\\b(?!'))  \n         # Decreasing indentation\n   |(?=\\}|;)      # Explicit indentation\n   |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n       \\1\\s+\\S    # - more indented, or\n     | \\s*        # - starts with whitespace, followed by:\n       (?: $      #   - the end of the line (i.e. empty line), or\n       |\\{-[^@]   #   - the start of a block comment, or\n       |--+       #   - the start of a single-line comment.\n          (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                  # The double dash may not be followed by other operator characters\n                  # (then it would be an operator, not a comment)\n     )\n",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "begin": "(?x)\n  (?<!')\\b(where)\n  \\s*(\\{)(?!-)",
+            "end": "\\}",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.other.where.haskell"
+              },
+              "2": {
+                "name": "punctuation.brace.haskell"
+              }
+            },
+            "endCaptures": {
+              "1": {
+                "name": "punctuation.brace.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "include": "#gadt_constructor"
+              },
+              {
+                "match": ";",
+                "name": "punctuation.semicolon.haskell"
+              }
+            ]
+          },
+          {
+            "match": "\\b(?<!')(where)\\b(?!')",
+            "name": "keyword.other.where.haskell"
+          },
+          {
+            "include": "#deriving"
+          },
+          {
+            "include": "#gadt_constructor"
+          }
+        ]
+      },
+      {
+        "include": "#role_annotation"
+      },
+      {
+        "name": "meta.declaration.pattern.type.haskell",
+        "begin": "^(\\s*)(pattern)\\s+(.*?)\\s+(::|∷)(?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])",
+        "beginCaptures": {
+          "2": {
+            "name": "keyword.other.pattern.haskell"
+          },
+          "3": {
+            "patterns": [
+              {
+                "include": "#comma"
+              },
+              {
+                "include": "#data_constructor"
+              }
+            ]
+          },
+          "4": {
+            "name": "keyword.operator.double-colon.haskell"
+          }
+        },
+        "end": "(?x) # Detect end of pattern type definition by decreasing indentation:\n  (?=\\}|;)       # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )\n",
+        "patterns": [
+          {
+            "include": "#type_signature"
+          }
+        ]
+      },
+      {
+        "name": "meta.declaration.pattern.haskell",
+        "begin": "^\\s*(pattern)\\b(?!')",
+        "captures": {
+          "1": {
+            "name": "keyword.other.pattern.haskell"
+          }
+        },
+        "end": "(?x) # Detect end of pattern type definition by decreasing indentation:\n  (?=\\}|;)       # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )\n",
+        "patterns": [
+          {
+            "include": "$self"
+          }
+        ]
+      },
+      {
+        "begin": "(?x)\n  # Data declaration\n  ^(\\s*)(data|newtype)(?:\\s+(family|instance))?\\s+\n  # Keep consuming characters until:\n  (((?!\n  # the equals symbol or the start of a single-line comment, or\n    (?: \n      (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]) # non-symbol\n      (?:=|--+)\n      (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])  # non-symbol\n    )\n  # the \"where\" or \"deriving\" keywords, or\n  | (?:\\b(?<!')(?:where|deriving)\\b(?!'))\n  # the start of a block comment.\n  | {-\n  #\n  ).)*)",
+        "beginCaptures": {
+          "2": {
+            "name": "keyword.other.$2.haskell"
+          },
+          "3": {
+            "name": "keyword.other.$3.haskell"
+          },
+          "4": {
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ]
+          }
+        },
+        "name": "meta.declaration.$2.algebraic.haskell",
+        "end": "(?x) # Detect end of data declaration: \n     # Decreasing indentation\n   (?=\\}|;)      # Explicit indentation\n   |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n       \\1\\s+\\S    # - more indented, or\n     | \\s*        # - starts with whitespace, followed by:\n       (?: $      #   - the end of the line (i.e. empty line), or\n       |\\{-[^@]   #   - the start of a block comment, or\n       |--+       #   - the start of a single-line comment.\n          (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                  # The double dash may not be followed by other operator characters\n                  # (then it would be an operator, not a comment)\n     )",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "include": "#deriving"
+          },
+          {
+            "include": "#forall"
+          },
+          {
+            "include": "#adt_constructor"
+          },
+          {
+            "include": "#data_context"
+          },
+          {
+            "include": "#record_decl"
+          },
+          {
+            "include": "#type_signature"
+          }
+        ]
+      },
+      {
+        "name": "meta.declaration.type.family.haskell",
+        "begin": "(?x)\n  # Type family\n  ^(\\s*)(type)\\s+(family)\\b(?!')\n  # Keep consuming characters until:\n  (((?!\n  # the equals symbol or the start of a single-line comment, or\n    (?: \n      (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]) # non-symbol\n      (?:=|--+)\n      (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])  # non-symbol\n    )\n  # the \"where\" keyword, or\n  | \\b(?<!')where\\b(?!')\n  # the start of a block comment.\n  | {-\n  #\n  ).)*)",
+        "beginCaptures": {
+          "2": {
+            "name": "keyword.other.type.haskell"
+          },
+          "3": {
+            "name": "keyword.other.family.haskell"
+          },
+          "4": {
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "include": "#where"
+              },
+              {
+                "include": "#type_signature"
+              }
+            ]
+          }
+        },
+        "end": "(?x) # Detect end of type family by decreasing indentation:\n  (?=\\}|;)       # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )\n",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "include": "#where"
+          },
+          {
+            "include": "#type_signature"
+          }
+        ]
+      },
+      {
+        "name": "meta.declaration.type.haskell",
+        "begin": "(?x)\n  # Type declaration\n  ^(\\s*)(type)(?:\\s+(instance))?\\s+\n  # Keep consuming characters until:\n  (((?!\n  # the equals symbol, the start of a single-line comment, or a type signature\n    (?: \n      (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]) # non-symbol\n      (?:=|--+|::|∷)\n      (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])  # non-symbol\n    )\n  # the start of a block comment.\n  | {-\n  #\n  ).)*)",
+        "beginCaptures": {
+          "2": {
+            "name": "keyword.other.type.haskell"
+          },
+          "3": {
+            "name": "keyword.other.instance.haskell"
+          },
+          "4": {
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ]
+          }
+        },
+        "end": "(?x) # Detect end of type definition by decreasing indentation:\n  (?=\\}|;)       # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )\n",
+        "patterns": [
+          {
+            "include": "#type_signature"
+          }
+        ]
+      },
+      {
+        "begin": "^(\\s*)(instance)(\\b(?!'))",
+        "beginCaptures": {
+          "2": {
+            "name": "keyword.other.instance.haskell"
+          }
+        },
+        "end": "(?x) # Detect end of instance declaration:\n  # 'where' keyword\n  (?=\\b(?<!')(where)\\b(?!'))\n  # Decreasing indentation\n  |(?=\\}|;)      # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )\n",
+        "name": "meta.declaration.instance.haskell",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "include": "#where"
+          },
+          {
+            "include": "#type_signature"
+          }
+        ]
+      },
+      {
+        "begin": "^(\\s*)(import)(\\b(?!'))",
+        "beginCaptures": {
+          "2": {
+            "name": "keyword.other.import.haskell"
+          }
+        },
+        "end": "(?x) # Detect end of import\n  # 'where' keyword\n  (?=\\b(?<!')(where)\\b(?!'))\n  # Decreasing indentation\n  |(?=\\}|;)      # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )\n",
+        "name": "meta.import.haskell",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "include": "#where"
+          },
+          {
+            "match": "(qualified|as|hiding)",
+            "captures": {
+              "1": {
+                "name": "keyword.other.$1.haskell"
+              }
+            }
+          },
+          {
+            "include": "#module_name"
+          },
+          {
+            "include": "#module_exports"
+          }
+        ]
+      },
+      {
+        "include": "#deriving"
+      },
+      {
+        "include": "#layout_herald"
+      },
+      {
+        "include": "#keyword"
+      },
+      {
+        "match": "^\\s*(infix[lr]?)\\s+(.*)",
+        "captures": {
+          "1": {
+            "name": "keyword.other.fixity.$1.haskell"
+          },
+          "2": {
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "include": "#integer_literals"
+              },
+              {
+                "match": ":[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]*",
+                "name": "constant.other.operator.infix.haskell"
+              },
+              {
+                "include": "#infix_op"
+              }
+            ]
+          }
+        },
+        "name": "meta.fixity-declaration.haskell"
+      },
+      {
+        "include": "#start_type_signature"
+      },
+      {
+        "include": "#overloaded_label"
+      },
+      {
+        "include": "#type_application"
+      },
+      {
+        "include": "#reserved_symbol"
+      },
+      {
+        "include": "#fun_decl"
+      },
+      {
+        "include": "#qualifier"
+      },
+      {
+        "match": ":[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]*",
+        "name": "constant.other.operator.infix.haskell"
+      },
+      {
+        "include": "#data_constructor"
+      },
+      {
+        "include": "#prefix_op"
+      },
+      {
+        "include": "#infix_op"
+      },
+      {
+        "begin": "(\\()(#)\\s",
+        "end": "(#)(\\))",
+        "beginCaptures": {
+          "1": {
+            "name": "punctuation.paren.haskell"
+          },
+          "2": {
+            "name": "keyword.operator.hash.haskell"
+          }
+        },
+        "endCaptures": {
+          "1": {
+            "name": "keyword.operator.hash.haskell"
+          },
+          "2": {
+            "name": "punctuation.paren.haskell"
+          }
+        },
+        "patterns": [
+          {
+            "include": "#comma"
+          },
+          {
+            "include": "$self"
+          }
+        ]
+      },
+      {
+        "begin": "(\\()",
+        "end": "(\\))",
+        "beginCaptures": {
+          "1": {
+            "name": "punctuation.paren.haskell"
+          }
+        },
+        "endCaptures": {
+          "1": {
+            "name": "punctuation.paren.haskell"
+          }
+        },
+        "patterns": [
+          {
+            "include": "#comma"
+          },
+          {
+            "include": "$self"
+          }
+        ]
+      },
+      {
+        "include": "#quasi_quote"
+      },
+      {
+        "begin": "(\\[)",
+        "end": "(\\])",
+        "beginCaptures": {
+          "1": {
+            "name": "punctuation.bracket.haskell"
+          }
+        },
+        "endCaptures": {
+          "1": {
+            "name": "punctuation.bracket.haskell"
+          }
+        },
+        "patterns": [
+          {
+            "include": "#comma"
+          },
+          {
+            "include": "$self"
+          }
+        ]
+      },
+      {
+        "include": "#record"
+      }
+    ],
+    "repository": {
+      "block_comment": {
+        "applyEndPatternLast": 1,
+        "begin": "\\{-",
+        "captures": {
+          "0": {
+            "name": "punctuation.definition.comment.haskell"
+          }
+        },
+        "end": "-\\}",
+        "name": "comment.block.haskell",
+        "patterns": [
+          {
+            "include": "#block_comment"
+          }
+        ]
+      },
+      "comments": {
+        "patterns": [
+          {
+            "begin": "^(\\s*)(--\\s[\\|\\$])",
+            "beginCaptures": {
+              "2": {
+                "name": "punctuation.whitespace.comment.leading.haskell"
+              }
+            },
+            "end": "(?=^(?!\\1--+(?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])))",
+            "name": "comment.block.documentation.haskell"
+          },
+          {
+            "begin": "(^[ \\t]+)?(--\\s[\\^\\*])",
+            "beginCaptures": {
+              "1": {
+                "name": "punctuation.whitespace.comment.leading.haskell"
+              }
+            },
+            "end": "\\n",
+            "name": "comment.line.documentation.haskell"
+          },
+          {
+            "applyEndPatternLast": 1,
+            "begin": "\\{-\\s?[\\|\\$\\*\\^]",
+            "captures": {
+              "0": {
+                "name": "punctuation.definition.comment.haskell"
+              }
+            },
+            "end": "-\\}",
+            "name": "comment.block.documentation.haskell",
+            "patterns": [
+              {
+                "include": "#block_comment"
+              }
+            ]
+          },
+          {
+            "begin": "(^[ \\t]+)?(?=--+(?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]))",
+            "beginCaptures": {
+              "1": {
+                "name": "punctuation.whitespace.comment.leading.haskell"
+              }
+            },
+            "comment": "Operators may begin with '--' as long as they are not entirely composed of '-' characters. This means comments can't be immediately followed by an allowable operator character.",
+            "end": "(?!\\G)",
+            "patterns": [
+              {
+                "begin": "--",
+                "beginCaptures": {
+                  "0": {
+                    "name": "punctuation.definition.comment.haskell"
+                  }
+                },
+                "end": "\\n",
+                "name": "comment.line.double-dash.haskell"
+              }
+            ]
+          },
+          {
+            "include": "#block_comment"
+          }
+        ]
+      },
+      "comment_like": {
+        "patterns": [
+          {
+            "include": "#cpp"
+          },
+          {
+            "include": "#pragma"
+          },
+          {
+            "include": "#comments"
+          }
+        ]
+      },
+      "cpp": {
+        "captures": {
+          "1": {
+            "name": "punctuation.definition.preprocessor.c"
+          }
+        },
+        "comment": "In addition to Haskell's \"native\" syntax, GHC permits the C preprocessor to be run on a source file.",
+        "match": "^(#).*$",
+        "name": "meta.preprocessor.c"
+      },
+      "where": {
+        "patterns": [
+          {
+            "begin": "(?x)\n  (?<!')\\b(where)\n  \\s*(\\{)(?!-)",
+            "end": "(\\})",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.other.where.haskell"
+              },
+              "2": {
+                "name": "punctuation.brace.haskell"
+              }
+            },
+            "endCaptures": {
+              "1": {
+                "name": "punctuation.brace.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "$self"
+              },
+              {
+                "match": ";",
+                "name": "punctuation.semicolon.haskell"
+              }
+            ]
+          },
+          {
+            "match": "\\b(?<!')(where)\\b(?!')",
+            "name": "keyword.other.where.haskell"
+          }
+        ]
+      },
+      "layout_herald": {
+        "begin": "(?x)\n  (?:(?<!')\\b(?:(where|let|m?do)|(of))|(\\\\\\s*case(?:s)?))\n  \\s*(\\{)(?!-)",
+        "end": "(\\})",
+        "beginCaptures": {
+          "1": {
+            "name": "keyword.other.$1.haskell"
+          },
+          "2": {
+            "name": "keyword.control.of.haskell"
+          },
+          "3": {
+            "name": "keyword.control.lambda-case.haskell"
+          },
+          "4": {
+            "name": "punctuation.brace.haskell"
+          }
+        },
+        "endCaptures": {
+          "1": {
+            "name": "punctuation.brace.haskell"
+          }
+        },
+        "patterns": [
+          {
+            "include": "$self"
+          },
+          {
+            "match": ";",
+            "name": "punctuation.semicolon.haskell"
+          }
+        ]
+      },
+      "keyword": {
+        "match": "\\b(?<!')(?:(where|let|in|default)|(m?do|if|then|else|case(?:s)?|of|proc|rec))\\b(?!')",
+        "captures": {
+          "1": {
+            "name": "keyword.other.$1.haskell"
+          },
+          "2": {
+            "name": "keyword.control.$2.haskell"
+          }
+        }
+      },
+      "deriving": {
+        "patterns": [
+          {
+            "begin": "^(\\s*)(deriving)\\s+(?:(via|stock|newtype|anyclass)\\s+)?",
+            "beginCaptures": {
+              "2": {
+                "name": "keyword.other.deriving.haskell"
+              },
+              "3": {
+                "name": "keyword.other.deriving.strategy.$3.haskell"
+              }
+            },
+            "end": "(?x) # Detect end of deriving statement\n  # Decreasing indentation\n   (?=\\}|;)      # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )",
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "match": "(?<!')\\b(instance)\\b(?!')",
+                "name": "keyword.other.instance.haskell"
+              },
+              {
+                "match": "(?<!')\\b(via|stock|newtype|anyclass)\\b(?!')",
+                "captures": {
+                  "1": {
+                    "name": "keyword.other.deriving.strategy.$1.haskell"
+                  }
+                }
+              },
+              {
+                "include": "#type_signature"
+              }
+            ],
+            "name": "meta.deriving.haskell"
+          },
+          {
+            "begin": "(deriving)(?:\\s+(stock|newtype|anyclass))?\\s*(\\()",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.other.deriving.haskell"
+              },
+              "2": {
+                "name": "keyword.other.deriving.strategy.$2.haskell"
+              },
+              "3": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "end": "(\\))",
+            "endCaptures": {
+              "1": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "name": "meta.deriving.haskell",
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ]
+          },
+          {
+            "match": "(?x)\n  (deriving)(?:\\s+(stock|newtype|anyclass))?\\s+\n    ([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\n    (\\s+(via)\\s+(.*)$)?\n",
+            "captures": {
+              "1": {
+                "name": "keyword.other.deriving.haskell"
+              },
+              "2": {
+                "name": "keyword.other.deriving.strategy.$2.haskell"
+              },
+              "3": {
+                "patterns": [
+                  {
+                    "include": "#type_signature"
+                  }
+                ]
+              },
+              "5": {
+                "name": "keyword.other.deriving.strategy.via.haskell"
+              },
+              "6": {
+                "patterns": [
+                  {
+                    "include": "#type_signature"
+                  }
+                ]
+              }
+            },
+            "name": "meta.deriving.haskell"
+          },
+          {
+            "match": "(?<!')\\b(via)\\b(?!')",
+            "name": "keyword.other.deriving.strategy.via.haskell"
+          }
+        ]
+      },
+      "prefix_op": {
+        "patterns": [
+          {
+            "comment": "An operator cannot be composed entirely of '-' characters;  instead, it should be matched as a comment.\n",
+            "match": "(?x)\n  (\\()\\s*(?!(?:--+|\\.\\.)\\))(\\#+|[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+(?<!\\#))\\s*(\\))",
+            "captures": {
+              "1": {
+                "name": "punctuation.paren.haskell"
+              },
+              "2": {
+                "name": "entity.name.function.infix.haskell"
+              },
+              "3": {
+                "name": "punctuation.paren.haskell"
+              }
+            }
+          }
+        ]
+      },
+      "infix_op": {
+        "patterns": [
+          {
+            "match": "(?x)\n  ((?:(?<!'')('')?[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}'']*\\.)*)\n    (\\#+|[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+(?<!\\#))",
+            "comment": "In case this regex seems overly general, note that Haskell permits  the definition of new operators which can be nearly any string of  punctuation characters, such as $%^&*.\n",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "2": {
+                "name": "entity.name.namespace.haskell"
+              },
+              "3": {
+                "name": "keyword.operator.infix.haskell"
+              }
+            }
+          },
+          {
+            "match": "(`)((?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}'']*\\.)*)([\\p{Ll}\\p{Lu}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}'']*)(`)",
+            "captures": {
+              "1": {
+                "name": "punctuation.backtick.haskell"
+              },
+              "2": {
+                "name": "entity.name.namespace.haskell"
+              },
+              "3": {
+                "patterns": [
+                  {
+                    "include": "#data_constructor"
+                  }
+                ]
+              },
+              "4": {
+                "name": "punctuation.backtick.haskell"
+              }
+            },
+            "comment": "In case this regex seems unusual for an infix operator, note that Haskell\nallows any ordinary function application (elem 4 [1..10]) to be rewritten\nas an infix expression (4 `elem` [1..10]).\n",
+            "name": "keyword.operator.function.infix.haskell"
+          }
+        ]
+      },
+      "module_exports": {
+        "begin": "\\(",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.paren.haskell"
+          }
+        },
+        "end": "\\)",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.paren.haskell"
+          }
+        },
+        "applyEndPatternLast": 1,
+        "name": "meta.declaration.exports.haskell",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "match": "\\b(?<!')(module)\\b(?!')",
+            "captures": {
+              "1": {
+                "name": "keyword.other.module.haskell"
+              }
+            }
+          },
+          {
+            "include": "#comma"
+          },
+          {
+            "include": "#export_constructs"
+          },
+          {
+            "begin": "\\(",
+            "beginCaptures": {
+              "0": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "end": "\\)",
+            "endCaptures": {
+              "0": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "include": "#record_wildcard"
+              },
+              {
+                "match": "(\\()\\s*(:[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]*)\\s*(\\))",
+                "name": "constant.other.operator.prefix.haskell"
+              },
+              {
+                "include": "#export_constructs"
+              },
+              {
+                "include": "#comma"
+              }
+            ]
+          }
+        ]
+      },
+      "export_constructs": {
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "begin": "\\b(?<!')(pattern)\\b(?!')",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.other.pattern.haskell"
+              }
+            },
+            "end": "(?x)\n   # Data constructor\n   ([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\n   # Prefix form of symbolic constructor\n   | (\\()\\s*(:[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+)\\s*(\\))",
+            "endCaptures": {
+              "1": {
+                "name": "constant.other.haskell"
+              },
+              "2": {
+                "name": "punctuation.paren.haskell"
+              },
+              "3": {
+                "name": "constant.other.operator.prefix.haskell"
+              },
+              "4": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#comment_like"
+              }
+            ]
+          },
+          {
+            "begin": "\\b(?<!')(type)\\b(?!')",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.other.type.haskell"
+              }
+            },
+            "end": "(?x)\n   # Type name\n   ([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\n   # Prefix form of type operator\n   | (\\()\\s*([\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+)\\s*(\\))",
+            "endCaptures": {
+              "1": {
+                "name": "storage.type.haskell"
+              },
+              "2": {
+                "name": "punctuation.paren.haskell"
+              },
+              "3": {
+                "name": "storage.type.operator.haskell"
+              },
+              "4": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#comment_like"
+              }
+            ]
+          },
+          {
+            "include": "#record_wildcard"
+          },
+          {
+            "include": "#reserved_symbol"
+          },
+          {
+            "match": "(\\()\\s*(:[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]*)\\s*(\\))",
+            "name": "storage.type.operator.haskell"
+          },
+          {
+            "match": "(?<!')\\b[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*",
+            "name": "entity.name.function.haskell"
+          },
+          {
+            "match": "(?<!')\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*",
+            "name": "storage.type.haskell"
+          },
+          {
+            "include": "#prefix_op"
+          }
+        ]
+      },
+      "comma": {
+        "match": ",",
+        "name": "punctuation.separator.comma.haskell"
+      },
+      "module_name": {
+        "match": "(?<conid>[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*(\\.\\g<conid>)?)",
+        "name": "entity.name.namespace.haskell"
+      },
+      "pragma": {
+        "begin": "\\{-#",
+        "end": "#-\\}",
+        "name": "meta.preprocessor.haskell",
+        "patterns": [
+          {
+            "include": "#comments"
+          },
+          {
+            "begin": "(?xi) \\b(?<!')(LANGUAGE)\\b(?!')",
+            "end": "(?=#-\\})",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.other.preprocessor.pragma.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#comments"
+              },
+              {
+                "match": "(?x)\n  \\b(?<!')\n  (?:No)?\n  (?:AutoDeriveTypeable|DatatypeContexts|DoRec|IncoherentInstances|MonadFailDesugaring|MonoPatBinds|NullaryTypeClasses|OverlappingInstances|PatternSignatures|RecordPuns|RelaxedPolyRec)\n  \\b(?!')",
+                "name": "invalid.deprecated"
+              },
+              {
+                "match": "(?x)\n  \\b(?<!')\n  (\n  (?:No)?\n  (?:AllowAmbiguousTypes|AlternativeLayoutRuleTransitional|AlternativeLayoutRule|Arrows|BangPatterns|BinaryLiterals|CApiFFI|CPP|CUSKs|ConstrainedClassMethods|ConstraintKinds|DataKinds|DefaultSignatures|DeriveAnyClass|DeriveDataTypeable|DeriveFoldable|DeriveFunctor|DeriveGeneric|DeriveLift|DeriveTraversable|DerivingStrategies|DerivingVia|DisambiguateRecordFields|DoAndIfThenElse|BlockArguments|DuplicateRecordFields|EmptyCase|EmptyDataDecls|EmptyDataDeriving|ExistentialQuantification|ExplicitForAll|ExplicitNamespaces|ExtendedDefaultRules|FlexibleContexts|FlexibleInstances|ForeignFunctionInterface|FunctionalDependencies|GADTSyntax|GADTs|GHCForeignImportPrim|Generali(?:s|z)edNewtypeDeriving|ImplicitParams|ImplicitPrelude|ImportQualifiedPost|ImpredicativeTypes|TypeFamilyDependencies|InstanceSigs|ApplicativeDo|InterruptibleFFI|JavaScriptFFI|KindSignatures|LambdaCase|LexicalNegation|LiberalTypeSynonyms|LinearTypes|MagicHash|MonadComprehensions|MonoLocalBinds|MonomorphismRestriction|MultiParamTypeClasses|MultiWayIf|NumericUnderscores|NPlusKPatterns|NamedFieldPuns|NamedWildCards|NegativeLiterals|HexFloatLiterals|NondecreasingIndentation|NumDecimals|OverloadedLabels|OverloadedLists|OverloadedStrings|PackageImports|ParallelArrays|ParallelListComp|PartialTypeSignatures|PatternGuards|PatternSynonyms|PolyKinds|PolymorphicComponents|QualifiedDo|QuantifiedConstraints|PostfixOperators|QuasiQuotes|Rank2Types|RankNTypes|RebindableSyntax|RecordWildCards|RecursiveDo|RelaxedLayout|RoleAnnotations|ScopedTypeVariables|StandaloneDeriving|StarIsType|StaticPointers|StrictData|Strict|TemplateHaskellQuotes|TemplateHaskell|StandaloneKindSignatures|TraditionalRecordSyntax|TransformListComp|TupleSections|TypeApplications|TypeInType|TypeFamilies|TypeOperators|TypeSynonymInstances|UnboxedTuples|UnboxedSums|UndecidableInstances|UndecidableSuperClasses|UnicodeSyntax|UnliftedFFITypes|UnliftedNewtypes|ViewPatterns|UnliftedDatatypes|OverloadedRecordDot|OverloadedRecordUpdate|FieldSelectors)\n  )\n  \\b(?!')",
+                "captures": {
+                  "1": {
+                    "name": "keyword.other.preprocessor.extension.haskell"
+                  }
+                }
+              },
+              {
+                "include": "#comma"
+              }
+            ]
+          },
+          {
+            "begin": "(?xi)\n  \\b(?<!')(SPECIALI(?:S|Z)E)\n  (?:\n  \\s*( \\[ [^\\[\\]]* \\])?\\s*\n  |\\s+\n  )\n  (instance)\\b(?!')",
+            "end": "(?=#-\\})",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.other.preprocessor.pragma.haskell"
+              },
+              "2": {
+                "patterns": [
+                  {
+                    "include": "#inline_phase"
+                  }
+                ]
+              },
+              "3": {
+                "name": "keyword.other.instance.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ]
+          },
+          {
+            "begin": "(?xi)\n  \\b(?<!')(SPECIALI(?:S|Z)E)\\b(?!')\n  (?:\\s+(INLINE)\\b(?!'))?\n  (?:\\s*(\\[ [^\\[\\]]* \\])?)\n  \\s*",
+            "end": "(?=#-\\})",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.other.preprocessor.pragma.haskell"
+              },
+              "2": {
+                "name": "keyword.other.preprocessor.pragma.haskell"
+              },
+              "3": {
+                "patterns": [
+                  {
+                    "include": "#inline_phase"
+                  }
+                ]
+              }
+            },
+            "patterns": [
+              {
+                "include": "$self"
+              }
+            ]
+          },
+          {
+            "match": "(?xi) \\b(?<!')\n  (LANGUAGE|OPTIONS_GHC|OPTIONS_HADDOCK|OPTIONS|INCLUDE\n  |MINIMAL|UNPACK|OVERLAPS|INCOHERENT\n  |NOUNPACK|SOURCE|OVERLAPPING|OVERLAPPABLE|INLINE\n  |NOINLINE|INLINE?ABLE|CONLIKE|LINE|COLUMN|RULES\n  |COMPLETE)\\b(?!')",
+            "name": "keyword.other.preprocessor.haskell"
+          },
+          {
+            "begin": "(?i)\\b(DEPRECATED|WARNING)\\b",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.other.preprocessor.pragma.haskell"
+              }
+            },
+            "end": "(?=#-\\})",
+            "patterns": [
+              {
+                "include": "#comments"
+              },
+              {
+                "include": "#string_literal"
+              }
+            ]
+          }
+        ]
+      },
+      "liquid_haskell": {
+        "name": "block.liquidhaskell.haskell",
+        "begin": "\\{-@",
+        "end": "@-\\}",
+        "patterns": [
+          {
+            "include": "$self"
+          }
+        ]
+      },
+      "data_context": {
+        "match": "(?x)\n  (.*)\n  (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])\n  (=>|⇒)\n  (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])\n",
+        "captures": {
+          "1": {
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "include": "#forall"
+              },
+              {
+                "begin": "(?='?\\()",
+                "end": "(?=\\))",
+                "patterns": [
+                  {
+                    "include": "#type_signature"
+                  }
+                ]
+              },
+              {
+                "begin": "(?='?\\[)",
+                "end": "(?=\\])",
+                "patterns": [
+                  {
+                    "include": "#type_signature"
+                  }
+                ]
+              },
+              {
+                "match": "(?x)\n  (\\S*)\\s*\n  (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])\n  (::|∷|=)\n  (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])",
+                "captures": {
+                  "1": {
+                    "patterns": [
+                      {
+                        "include": "#comment_like"
+                      },
+                      {
+                        "include": "#forall"
+                      },
+                      {
+                        "include": "#record_decl_field"
+                      }
+                    ]
+                  },
+                  "2": {
+                    "patterns": [
+                      {
+                        "include": "#reserved_symbol"
+                      }
+                    ]
+                  },
+                  "3": {
+                    "patterns": [
+                      {
+                        "include": "#type_signature"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "include": "#type_signature"
+              }
+            ]
+          },
+          "2": {
+            "name": "keyword.operator.big-arrow.haskell"
+          }
+        }
+      },
+      "data_constructor": {
+        "patterns": [
+          {
+            "match": "\\b(?<!')[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*(?![\\.'\\w])",
+            "name": "constant.other.haskell"
+          },
+          {
+            "match": "(\\()\\s*(:[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]*)\\s*(\\))",
+            "name": "constant.other.operator.haskell"
+          }
+        ]
+      },
+      "qualifier": {
+        "match": "\\b(?<!')[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*\\.",
+        "name": "entity.name.namespace.haskell"
+      },
+      "record_decl": {
+        "begin": "({)(?!-)",
+        "beginCaptures": {
+          "1": {
+            "name": "punctuation.brace.haskell"
+          }
+        },
+        "end": "(?<!-)(})",
+        "endCaptures": {
+          "1": {
+            "name": "punctuation.brace.haskell"
+          }
+        },
+        "name": "meta.record.definition.haskell",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "include": "#record_decl_field"
+          }
+        ]
+      },
+      "record": {
+        "begin": "({)(?!-)",
+        "beginCaptures": {
+          "1": {
+            "name": "punctuation.brace.haskell"
+          }
+        },
+        "end": "(?<!-)(})",
+        "endCaptures": {
+          "1": {
+            "name": "punctuation.brace.haskell"
+          }
+        },
+        "name": "meta.record.haskell",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "include": "#record_field"
+          }
+        ]
+      },
+      "record_decl_field": {
+        "begin": "(?x)\n  (?:([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\n    |(\\()\\s*([\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+)\\s*(\\))\n  )\n",
+        "end": "(,)|(?=})",
+        "beginCaptures": {
+          "1": {
+            "name": "variable.other.member.definition.haskell"
+          },
+          "2": {
+            "name": "punctuation.paren.haskell"
+          },
+          "3": {
+            "name": "variable.other.member.definition.haskell"
+          },
+          "4": {
+            "name": "punctuation.paren.haskell"
+          }
+        },
+        "endCaptures": {
+          "1": {
+            "name": "punctuation.comma.haskell"
+          }
+        },
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "include": "#comma"
+          },
+          {
+            "include": "#double_colon"
+          },
+          {
+            "include": "#type_signature"
+          },
+          {
+            "include": "#record_decl_field"
+          }
+        ]
+      },
+      "record_wildcard": {
+        "match": "(?x)\n  (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])\n  (\\.\\.)\n  (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])",
+        "captures": {
+          "1": {
+            "name": "variable.other.member.wildcard.haskell"
+          }
+        }
+      },
+      "record_field": {
+        "patterns": [
+          {
+            "begin": "(?x)\n  (?:([\\p{Ll}\\p{Lu}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\\.']*)\n    |(\\()\\s*([\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+)\\s*(\\))\n  )\n",
+            "end": "(,)|(?=})",
+            "beginCaptures": {
+              "1": {
+                "name": "variable.other.member.haskell",
+                "patterns": [
+                  {
+                    "include": "#qualifier"
+                  }
+                ]
+              },
+              "2": {
+                "name": "punctuation.paren.haskell"
+              },
+              "3": {
+                "name": "variable.other.member.haskell"
+              },
+              "4": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "endCaptures": {
+              "1": {
+                "name": "punctuation.comma.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "include": "#comma"
+              },
+              {
+                "include": "$self"
+              }
+            ]
+          },
+          {
+            "include": "#record_wildcard"
+          }
+        ]
+      },
+      "role_annotation": {
+        "patterns": [
+          {
+            "begin": "^(\\s*)(type)\\s+(role)\\b(?!')",
+            "beginCaptures": {
+              "2": {
+                "name": "keyword.other.type.haskell"
+              },
+              "3": {
+                "name": "keyword.other.role.haskell"
+              }
+            },
+            "end": "(?x) # Detect end of block by decreasing indentation:\n  (?=\\}|;)       # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )",
+            "name": "meta.role-annotation.haskell",
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "include": "#type_constructor"
+              },
+              {
+                "match": "\\b(?<!')(nominal|representational|phantom)\\b(?!')",
+                "captures": {
+                  "1": {
+                    "name": "keyword.other.role.$1.haskell"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "fun_decl": {
+        "begin": "(?x)^(\\s*)\n  (?<fn>\n    (?:\n      [\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*\\#*\n    | \\(\\s*\n        (?!--+\\))\n        [\\p{S}\\p{P}&&[^(),:;\\[\\]`{}_\"']]\n        [\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]*\n      \\s*\\)\n    )\n    (?:\\s*,\\s*\\g<fn>)?\n  )\n  \\s*(?<![\\p{S}\\p{P}&&[^\\),;\\]`}_\"']])(::|∷)(?![\\p{S}\\p{P}&&[^\\(,;\\[`{_\"']])\n",
+        "beginCaptures": {
+          "2": {
+            "name": "entity.name.function.haskell",
+            "patterns": [
+              {
+                "include": "#reserved_symbol"
+              },
+              {
+                "include": "#prefix_op"
+              }
+            ]
+          },
+          "3": {
+            "name": "keyword.operator.double-colon.haskell"
+          }
+        },
+        "name": "meta.function.type-declaration.haskell",
+        "patterns": [
+          {
+            "include": "#type_signature"
+          }
+        ],
+        "end": "(?x)\n  # End of type annotation:\n    # To the left of a reserved symbolic keyword such as = or <-\n  (?= \n      # non-symbolic character\n      (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])\n      # symbolic keyword except (->)\n      ((<-|←)|(=)|(-<|↢)|(-<<|⤛))\n      # non-symbolic character\n      ([(),;\\[\\]`{}_\"']|[^\\p{S}\\p{P}])\n  )\n  # Decreasing indentation:\n  |(?=\\}|;)      # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )\n"
+      },
+      "adt_constructor": {
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "begin": "(?x)\n  (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]) # non-symbol\n  (?:(=)|(\\|))\n  (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])  # non-symbol",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.eq.haskell"
+              },
+              "2": {
+                "name": "keyword.operator.pipe.haskell"
+              }
+            },
+            "end": "(?x)\n  (?: # Infix data constructor\n    # First argument\n    (?:\n    # Simple type\n      (?<!')\\b((?:[\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}'\\.])+)\n    # Type inside balanced parentheses\n    | ('? # Optional promotion tick\n        (?<paren>\n          \\(          # Opening parenthesis\n          (?:\n            [^\\(\\)]*  # Match non-parentheses\n          | \\g<paren> # or recurse into further depth\n          )*\n          \\)          # Closing parenthesis\n        )\n      )\n    # Type inside balanced brackets\n    | ('? # Optional promotion tick\n        (?<brac>\n          \\[          # Opening bracket\n          (?:\n            [^\\[\\]]*  # Match non-brackets\n          | \\g<brac>  # or recurse into further depth\n          )*\n          \\]          # Closing bracket\n        )\n      )\n    )\n    # Then either\n    \\s*\n      # - a symbolic infix constructor, or\n    (?:(?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])(:[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]*)\n      # - an alphabetic infix constructor\n    | (`)([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)(`)\n    )\n  ) # Otherwise, prefix data constructor, either:\n  | # - an alphabetic data constructor e.g. \"Cons_123\"\n    (?:(?<!')\\b([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*))\n  | # - a symbolic (prefix) data constructor\n    (\\()\\s*(:[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]*)\\s*(\\))\n  | # Otherwise, try to fail early to avoid excessive backtracking (https://github.com/JustusAdam/language-haskell/issues/161)\n      # Fail when detecting a lowercase identifier and then something not starting with a tick or colon\n      (?=\\b(?<!')(?!(?:forall|deriving)\\s)[\\p{Ll}_]\\S+\\s+[^`:])\n      # Fail when seeing another equal signs or pipe symbol\n     |(?=\n        (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]) # non-symbol\n        (?:=|\\|)\n        (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])  # non-symbol\n      )",
+            "endCaptures": {
+              "1": {
+                "patterns": [
+                  {
+                    "include": "#type_signature"
+                  }
+                ]
+              },
+              "2": {
+                "patterns": [
+                  {
+                    "include": "#type_signature"
+                  }
+                ]
+              },
+              "4": {
+                "patterns": [
+                  {
+                    "include": "#type_signature"
+                  }
+                ]
+              },
+              "6": {
+                "name": "constant.other.operator.infix.haskell"
+              },
+              "7": {
+                "name": "punctuation.backtick.haskell"
+              },
+              "8": {
+                "name": "constant.other.infix.haskell"
+              },
+              "9": {
+                "name": "punctuation.backtick.haskell"
+              },
+              "10": {
+                "name": "constant.other.haskell"
+              },
+              "11": {
+                "name": "punctuation.paren.haskell"
+              },
+              "12": {
+                "name": "constant.other.operator.prefix.haskell"
+              },
+              "13": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "include": "#deriving"
+              },
+              {
+                "include": "#record_decl"
+              },
+              {
+                "include": "#forall"
+              },
+              {
+                "include": "#data_context"
+              },
+              {
+                "include": "#type_signature"
+              }
+            ]
+          }
+        ]
+      },
+      "gadt_constructor": {
+        "patterns": [
+          {
+            "begin": "(?x)\n   ^(\\s*)\n      (?:\n        (\\b(?<!')[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\n      |(\\()\\s*(:[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]*)\\s*(\\))\n      )",
+            "beginCaptures": {
+              "2": {
+                "name": "constant.other.haskell"
+              },
+              "3": {
+                "name": "punctuation.paren.haskell"
+              },
+              "4": {
+                "name": "constant.other.operator.prefix.haskell"
+              },
+              "5": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "end": "(?x)\n  # GADT constructor ends\n  (?=\\b(?<!'')deriving\\b(?!'))  \n        # Decreasing indentation\n  |(?=\\}|;)      # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )\n",
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "include": "#deriving"
+              },
+              {
+                "include": "#double_colon"
+              },
+              {
+                "include": "#record_decl"
+              },
+              {
+                "include": "#type_signature"
+              }
+            ]
+          },
+          {
+            "begin": "(?x)\n  (\\b(?<!')[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}]*) # named constructor\n |(\\()\\s*(:[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]*)\\s*(\\))    # prefix operator",
+            "beginCaptures": {
+              "1": {
+                "name": "constant.other.haskell"
+              },
+              "2": {
+                "name": "punctuation.paren.haskell"
+              },
+              "3": {
+                "name": "constant.other.operator.prefix.haskell"
+              },
+              "4": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "end": "(?=;|\\}|$)",
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "include": "#deriving"
+              },
+              {
+                "include": "#double_colon"
+              },
+              {
+                "include": "#record_decl"
+              },
+              {
+                "include": "#type_signature"
+              }
+            ]
+          }
+        ]
+      },
+      "type_application": {
+        "patterns": [
+          {
+            "begin": "(?<=[\\s,;\\[\\]{}\"])(@)(')?(\\()",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.prefix.at.haskell"
+              },
+              "2": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "3": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "end": "\\)",
+            "endCaptures": {
+              "0": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "name": "meta.type-application.haskell",
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ]
+          },
+          {
+            "begin": "(?<=[\\s,;\\[\\]{}\"])(@)(')?(\\[)",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.prefix.at.haskell"
+              },
+              "2": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "3": {
+                "name": "punctuation.bracket.haskell"
+              }
+            },
+            "end": "\\]",
+            "name": "meta.type-application.haskell",
+            "endCaptures": {
+              "0": {
+                "name": "punctuation.bracket.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ]
+          },
+          {
+            "begin": "(?<=[\\s,;\\[\\]{}\"])(@)(?=\\\")",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.prefix.at.haskell"
+              }
+            },
+            "end": "(?<=\\\")",
+            "name": "meta.type-application.haskell",
+            "patterns": [
+              {
+                "include": "#string_literal"
+              }
+            ]
+          },
+          {
+            "begin": "(?<=[\\s,;\\[\\]{}\"])(@)(?=[\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}'])",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.prefix.at.haskell"
+              }
+            },
+            "end": "(?![\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}'])",
+            "name": "meta.type-application.haskell",
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ]
+          }
+        ]
+      },
+      "type_signature": {
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "match": "(')?(\\()\\s*(\\))",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "2": {
+                "name": "punctuation.paren.haskell"
+              },
+              "3": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "name": "support.constant.unit.haskell"
+          },
+          {
+            "match": "(\\()(#)\\s*(#)(\\))",
+            "name": "support.constant.unit.unboxed.haskell",
+            "captures": {
+              "1": {
+                "name": "punctuation.paren.haskell"
+              },
+              "2": {
+                "name": "keyword.operator.hash.haskell"
+              },
+              "3": {
+                "name": "keyword.operator.hash.haskell"
+              },
+              "4": {
+                "name": "punctuation.paren.haskell"
+              }
+            }
+          },
+          {
+            "match": "(')?(\\()\\s*,[\\s,]*(\\))",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "2": {
+                "name": "punctuation.paren.haskell"
+              },
+              "3": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "name": "support.constant.tuple.haskell"
+          },
+          {
+            "match": "(\\()(#)\\s*(#)(\\))",
+            "name": "support.constant.unit.unboxed.haskell",
+            "captures": {
+              "1": {
+                "name": "punctuation.paren.haskell"
+              },
+              "2": {
+                "name": "keyword.operator.hash.haskell"
+              },
+              "3": {
+                "name": "keyword.operator.hash.haskell"
+              },
+              "4": {
+                "name": "punctuation.paren.haskell"
+              }
+            }
+          },
+          {
+            "match": "(\\()(#)\\s*,[\\s,]*(#)(\\))",
+            "captures": {
+              "1": {
+                "name": "punctuation.paren.haskell"
+              },
+              "2": {
+                "name": "keyword.operator.hash.haskell"
+              },
+              "3": {
+                "name": "keyword.operator.hash.haskell"
+              },
+              "4": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "name": "support.constant.tuple.unboxed.haskell"
+          },
+          {
+            "match": "(')?(\\[)\\s*(\\])",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "2": {
+                "name": "punctuation.bracket.haskell"
+              },
+              "3": {
+                "name": "punctuation.bracket.haskell"
+              }
+            },
+            "name": "support.constant.empty-list.haskell"
+          },
+          {
+            "include": "#integer_literals"
+          },
+          {
+            "match": "(::|∷)(?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])",
+            "name": "keyword.operator.double-colon.haskell"
+          },
+          {
+            "include": "#forall"
+          },
+          {
+            "match": "=>|⇒",
+            "name": "keyword.operator.big-arrow.haskell"
+          },
+          {
+            "include": "#string_literal"
+          },
+          {
+            "match": "'[^']'",
+            "name": "invalid"
+          },
+          {
+            "include": "#type_application"
+          },
+          {
+            "include": "#reserved_symbol"
+          },
+          {
+            "include": "#type_operator"
+          },
+          {
+            "include": "#type_constructor"
+          },
+          {
+            "begin": "(\\()(#)",
+            "end": "(#)(\\))",
+            "beginCaptures": {
+              "1": {
+                "name": "punctuation.paren.haskell"
+              },
+              "2": {
+                "name": "keyword.operator.hash.haskell"
+              }
+            },
+            "endCaptures": {
+              "1": {
+                "name": "keyword.operator.hash.haskell"
+              },
+              "2": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#comma"
+              },
+              {
+                "include": "#type_signature"
+              }
+            ]
+          },
+          {
+            "begin": "(')?(\\()",
+            "end": "(\\))",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "2": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "endCaptures": {
+              "1": {
+                "name": "punctuation.paren.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#comma"
+              },
+              {
+                "include": "#type_signature"
+              }
+            ]
+          },
+          {
+            "begin": "(')?(\\[)",
+            "end": "(\\])",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "2": {
+                "name": "punctuation.bracket.haskell"
+              }
+            },
+            "endCaptures": {
+              "1": {
+                "name": "punctuation.bracket.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "include": "#comma"
+              },
+              {
+                "include": "#type_signature"
+              }
+            ]
+          },
+          {
+            "include": "#type_variable"
+          }
+        ]
+      },
+      "double_colon": {
+        "match": "\\s*(::|∷)(?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])\\s*",
+        "captures": {
+          "1": {
+            "name": "keyword.operator.double-colon.haskell"
+          }
+        }
+      },
+      "start_type_signature": {
+        "patterns": [
+          {
+            "begin": "^(\\s*)(::|∷)(?![\\p{S}\\p{P}&&[^\\(,;\\[`{_\"']])\\s*",
+            "beginCaptures": {
+              "2": {
+                "name": "keyword.operator.double-colon.haskell"
+              }
+            },
+            "end": "(?x)\n  # End type annotation when seeing one of:\n  (?=\n    \\#?\\)                             # closing parenthesis\n    |\\]                               # closing bracket\n    |,                                # comma\n    |(?<!')\\b(in|then|else|of)\\b(?!') # keyword\n    |                                 # symbolic keyword except (->)\n      (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])\n      (?:\n         (\\\\|λ)\n        |(<-|←)\n        |(=)\n        |(-<|↢)\n        |(-<<|⤛)\n      )\n      ([(),;\\[\\]`{}_\"']|[^\\p{S}\\p{P}])\n    |(\\#|@)-\\}                             # End of annotation block (LiquidHaskell or pragma)\n    # Decreasing indentation:\n    | (?=\\}|;)     # Explicit indentation\n    |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n        \\1\\s*\\S    # - equally indented, or\n      | \\s*        # - starts with whitespace, followed by:\n        (?: $      #   - the end of the line (i.e. empty line), or\n        |\\{-[^@]   #   - the start of a block comment, or\n        |--+       #   - the start of a single-line comment.\n           (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                   # The double dash may not be followed by other operator characters\n                   # (then it would be an operator, not a comment)\n      )\n  )",
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ],
+            "name": "meta.type-declaration.haskell"
+          },
+          {
+            "begin": "(?<![\\p{S}\\p{P}&&[^\\(,;\\[`{_\"']])(::|∷)(?![\\p{S}\\p{P}&&[^\\(,;\\[`{_\"']])",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.double-colon.haskell"
+              }
+            },
+            "end": "(?x)\n  # End type annotation when seeing one of:\n  (?=\n    \\#?\\)                             # closing parenthesis\n    |\\]                               # closing bracket\n    |,                                # comma\n    |\\b(?<!')(in|then|else|of)\\b(?!') # keyword\n    |(\\#|@)-\\}                        # End of annotation block (LiquidHaskell or pragma)\n    |                                 # symbolic keyword except (->)\n      (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']])\n      (?:\n         (\\\\|λ)\n        |(<-|←)\n        |(=)\n        |(-<|↢)\n        |(-<<|⤛)\n      )\n      ([(),;\\[\\]`{}_\"']|[^\\p{S}\\p{P}])\n    # Indentation \n    |(?=\\}|;)      # Explicit indentation\n    |$             # End of line\n  )",
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ]
+          }
+        ]
+      },
+      "type_variable": {
+        "match": "\\b(?<!')(?!(?:forall|deriving)\\b(?!'))[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*",
+        "name": "variable.other.generic-type.haskell"
+      },
+      "type_constructor": {
+        "patterns": [
+          {
+            "match": "(?x)\n  # Optional promotion tick\n    (')?\n  # Optional qualified name\n    ((?:\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*\\.)*)\n  # Type constructor proper\n    (\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "2": {
+                "name": "entity.name.namespace.haskell"
+              },
+              "3": {
+                "name": "storage.type.haskell"
+              }
+            }
+          },
+          {
+            "match": "(?x)\n  # Optional promotion tick\n    (')?\n  # Opening parenthesis\n    (\\()\\s*\n  # Optional qualified name\n    ((?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*\\.)*)\n  # Type operator proper\n    ([\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+)\n  # Closing parenthesis\n    \\s*(\\))",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "2": {
+                "name": "punctuation.paren.haskell"
+              },
+              "3": {
+                "name": "entity.name.namespace.haskell"
+              },
+              "4": {
+                "name": "storage.type.operator.haskell"
+              },
+              "5": {
+                "name": "punctuation.paren.haskell"
+              }
+            }
+          }
+        ]
+      },
+      "overloaded_label": {
+        "patterns": [
+          {
+            "match": "(?x) \n  (?<![\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\\p{S}\\p{P}&&[^(,;\\[`{]]) # Disallow closing characters\n  (\\#)\n    (?:\n    # String\n    (\"(?:\\\\\"|[^\"])*\")\n    # Sequence of allowed label identifiers\n    |[\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}'\\.]+\n    )",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.prefix.hash.haskell"
+              },
+              "2": {
+                "patterns": [
+                  {
+                    "include": "#string_literal"
+                  }
+                ]
+              }
+            },
+            "name": "entity.name.label.haskell"
+          }
+        ]
+      },
+      "reserved_symbol": {
+        "patterns": [
+          {
+            "match": "(?x)\n  (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"'']])\n  (?:\n     (\\.\\.)\n    |(:)\n    |(=)\n    |(\\\\)     # λ not reserved as it is a letter\n    |(\\|)\n    |(<-|←)\n    |(->|→)\n    |(-<|↢)\n    |(-<<|⤛)\n    |(>-|⤚)\n    |(>>-|⤜)\n  )\n  (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"'']])",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.double-dot.haskell"
+              },
+              "2": {
+                "name": "keyword.operator.colon.haskell"
+              },
+              "3": {
+                "name": "keyword.operator.eq.haskell"
+              },
+              "4": {
+                "name": "keyword.operator.lambda.haskell"
+              },
+              "5": {
+                "name": "keyword.operator.pipe.haskell"
+              },
+              "6": {
+                "name": "keyword.operator.arrow.left.haskell"
+              },
+              "7": {
+                "name": "keyword.operator.arrow.haskell"
+              },
+              "8": {
+                "name": "keyword.operator.arrow.left.tail.haskell"
+              },
+              "9": {
+                "name": "keyword.operator.arrow.left.tail.double.haskell"
+              },
+              "10": {
+                "name": "keyword.operator.arrow.tail.haskell"
+              },
+              "11": {
+                "name": "keyword.operator.arrow.tail.double.haskell"
+              }
+            }
+          },
+          {
+            "match": "(?x)\n  (?<=[\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\\p{S}\\p{P}&&[^\\#,;\\[`{]]) # Require closing characters\n  (\\#+)\n  (?![\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\\p{S}\\p{P}&&[^),;\\]`}]])   # Disallow opening character",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.postfix.hash.haskell"
+              }
+            }
+          },
+          {
+            "match": "(?x)\n  (?<=[\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}'\\)\\}\\]]) # Require closing characters\n  (@)\n  (?=[\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}'\\(\\[\\{]) # Require opening character",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.infix.tight.at.haskell"
+              }
+            }
+          },
+          {
+            "match": "(?x)\n  (?<![\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}\\p{S}\\p{P}&&[^(,;\\[`{]])  # Disallow closing characters\n  (?:(~)|(!)|(-)|(\\$\\$)|(\\$)|(%))\n  (?=[\\p{Ll}_'\\p{Lu}\\p{Lt}\\p{Nd}\\(\\{\\[]) # Require opening character (non operator symbol)",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.prefix.tilde.haskell"
+              },
+              "2": {
+                "name": "keyword.operator.prefix.bang.haskell"
+              },
+              "3": {
+                "name": "keyword.operator.prefix.minus.haskell"
+              },
+              "4": {
+                "name": "keyword.operator.prefix.double-dollar.haskell"
+              },
+              "5": {
+                "name": "keyword.operator.prefix.dollar.haskell"
+              },
+              "6": {
+                "name": "keyword.operator.prefix.modifier.haskell"
+              }
+            }
+          }
+        ]
+      },
+      "type_operator": {
+        "patterns": [
+          {
+            "match": "(?x)\n  # Optional promotion tick\n    (?:(?<!')('))?\n  # Optional qualified name\n    ((?:\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*\\.)*)\n  # Type operator proper\n    (?![#@]?-})(\\#+|[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+(?<!\\#))\n    #((?:[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']&&[^#@]]|[@#](?!-}))+)",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "2": {
+                "name": "entity.name.namespace.haskell"
+              },
+              "3": {
+                "name": "storage.type.operator.infix.haskell"
+              }
+            }
+          },
+          {
+            "match": "(?x)\n  # Optional promotion tick\n    (')?\n  # Opening backtick\n    (\\`)\n  # Optional qualified name\n    ((?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*\\.)*)\n  # Type constructor proper\n    ([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\n  # Closing backtick\n    (`)",
+            "captures": {
+              "1": {
+                "name": "keyword.operator.promotion.haskell"
+              },
+              "2": {
+                "name": "punctuation.backtick.haskell"
+              },
+              "3": {
+                "name": "entity.name.namespace.haskell"
+              },
+              "4": {
+                "name": "storage.type.infix.haskell"
+              },
+              "5": {
+                "name": "punctuation.backtick.haskell"
+              }
+            }
+          }
+        ]
+      },
+      "forall": {
+        "begin": "(?x)\n  # Alphabetic forall\n  (?:\n  \\b(?<!')\n  (forall)\n  \\b(?!')\n  )\n  |\n  # Symbolic forall\n  (?:\n  # Not preceded by a symbol except reserved symbols\n  (?<![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"'']])\n  (∀)\n  # Not followed by a symbol except reserved symbols\n  (?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"'']])\n  )",
+        "end": "(\\.)|(->|→)",
+        "beginCaptures": {
+          "1": {
+            "name": "keyword.other.forall.haskell"
+          },
+          "2": {
+            "name": "keyword.other.forall.haskell"
+          }
+        },
+        "endCaptures": {
+          "1": {
+            "name": "keyword.operator.period.haskell"
+          },
+          "2": {
+            "name": "keyword.operator.arrow.haskell"
+          }
+        },
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "include": "#type_variable"
+          },
+          {
+            "include": "#type_signature"
+          }
+        ]
+      },
+      "string_literal": {
+        "begin": "\"",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.begin.haskell"
+          }
+        },
+        "end": "\"",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.string.end.haskell"
+          }
+        },
+        "name": "string.quoted.double.haskell",
+        "patterns": [
+          {
+            "match": "\\\\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\\"'\\&])",
+            "name": "constant.character.escape.haskell"
+          },
+          {
+            "match": "\\\\o[0-7]+|\\\\x[0-9A-Fa-f]+|\\\\[0-9]+",
+            "name": "constant.character.escape.octal.haskell"
+          },
+          {
+            "match": "\\\\\\^[A-Z@\\[\\]\\\\\\^_]",
+            "name": "constant.character.escape.control.haskell"
+          },
+          {
+            "begin": "\\\\\\s",
+            "beginCaptures": {
+              "0": {
+                "name": "constant.character.escape.begin.haskell"
+              }
+            },
+            "end": "\\\\",
+            "endCaptures": {
+              "0": {
+                "name": "constant.character.escape.end.haskell"
+              }
+            },
+            "patterns": [
+              {
+                "match": "\\S+",
+                "name": "invalid.illegal.character-not-allowed-here.haskell"
+              }
+            ]
+          }
+        ]
+      },
+      "char_literal": {
+        "captures": {
+          "1": {
+            "name": "punctuation.definition.string.begin.haskell"
+          },
+          "2": {
+            "name": "constant.character.escape.haskell"
+          },
+          "3": {
+            "name": "constant.character.escape.octal.haskell"
+          },
+          "4": {
+            "name": "constant.character.escape.hexadecimal.haskell"
+          },
+          "5": {
+            "name": "constant.character.escape.control.haskell"
+          },
+          "6": {
+            "name": "punctuation.definition.string.end.haskell"
+          }
+        },
+        "match": "(?x)\n  (?<![\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}'])\n  (')\n  (?:\n    [\\ -\\[\\]-~]                         # Basic Char\n  | (\\\\(?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE\n       |DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS\n       |US|SP|DEL|[abfnrtv\\\\\\\"'\\\\&]))   # Escapes\n  | (\\\\o[0-7]+)                         # Octal Escapes\n  | (\\\\x[0-9A-Fa-f]+)                   # Hexadecimal Escapes\n  | (\\\\\\^[A-Z@\\[\\]\\\\\\^_])                 # Control Chars\n  )\n  (')\n",
+        "name": "string.quoted.single.haskell"
+      },
+      "float_literals": {
+        "comment": "Floats are decimal or hexadecimal",
+        "match": "(?x)\n  \\b(?<!')\n  (?:  # Decimal\n    ([0-9][_0-9]*\\.[0-9][_0-9]*(?:[eE][-+]?[0-9][_0-9]*)?\n    |[0-9][_0-9]*[eE][-+]?[0-9][_0-9]*\n    )\n  |    # Hexadecimal\n    (0[xX]_*[0-9a-fA-F][_0-9a-fA-F]*\\.[0-9a-fA-F][_0-9a-fA-F]*(?:[pP][-+]?[0-9][_0-9]*)?\n    |0[xX]_*[0-9a-fA-F][_0-9a-fA-F]*[pP][-+]?[0-9][_0-9]*\n    )\n  )\\b(?!')",
+        "captures": {
+          "1": {
+            "name": "constant.numeric.floating.decimal.haskell"
+          },
+          "2": {
+            "name": "constant.numeric.floating.hexadecimal.haskell"
+          }
+        }
+      },
+      "integer_literals": {
+        "match": "(?x)\n  \\b(?<!')\n  (?:\n    ([0-9][_0-9]*)                    # Decimal integer\n  | (0[xX]_*[0-9a-fA-F][_0-9a-fA-F]*) # Hexadecimal integer\n  | (0[oO]_*[0-7][_0-7]*)             # Octal integer\n  | (0[bB]_*[01][_01]*)               # Binary integer\n  )\n  \\b(?!')",
+        "captures": {
+          "1": {
+            "name": "constant.numeric.integral.decimal.haskell"
+          },
+          "2": {
+            "name": "constant.numeric.integral.hexadecimal.haskell"
+          },
+          "3": {
+            "name": "constant.numeric.integral.octal.haskell"
+          },
+          "4": {
+            "name": "constant.numeric.integral.binary.haskell"
+          }
+        }
+      },
+      "numeric_literals": {
+        "patterns": [
+          {
+            "include": "#float_literals"
+          },
+          {
+            "include": "#integer_literals"
+          }
+        ]
+      },
+      "ffi": {
+        "begin": "^(\\s*)(foreign)\\s+(import|export)\\s+",
+        "beginCaptures": {
+          "2": {
+            "name": "keyword.other.foreign.haskell"
+          },
+          "3": {
+            "name": "keyword.other.$3.haskell"
+          }
+        },
+        "name": "meta.$3.foreign.haskell",
+        "end": "(?x) # Detect end of FFI block by decreasing indentation:\n  (?=\\}|;)       # Explicit indentation\n  |^(?!          # Implicit indentation: end match on newline *unless* the new line is either:\n      \\1\\s+\\S    # - more indented, or\n    | \\s*        # - starts with whitespace, followed by:\n      (?: $      #   - the end of the line (i.e. empty line), or\n      |\\{-[^@]   #   - the start of a block comment, or\n      |--+       #   - the start of a single-line comment.\n         (?![\\p{S}\\p{P}&&[^(),;\\[\\]{}`_\"']]).*$) # non-symbol\n                 # The double dash may not be followed by other operator characters\n                 # (then it would be an operator, not a comment)\n    )\n",
+        "patterns": [
+          {
+            "include": "#comment_like"
+          },
+          {
+            "match": "\\b(?<!')(ccall|cplusplus|dotnet|jvm|stdcall|prim|capi)\\s+",
+            "captures": {
+              "1": {
+                "name": "keyword.other.calling-convention.$1.haskell"
+              }
+            }
+          },
+          {
+            "begin": "(?=\")|(?=\\b(?<!')([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\\b(?!'))",
+            "end": "(?=(::|∷)(?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]))",
+            "patterns": [
+              {
+                "include": "#comment_like"
+              },
+              {
+                "match": "(?x)\n  \\b(?<!')(safe|unsafe|interruptible)\\b(?!')\n  \\s*\n  (\"(?:\\\\\"|[^\"])*\")?\n  \\s*\n  (?:\n    (?:\\b(?<!'')([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\\b(?!'))\n   |(?:\\(\\s*(?!--+\\))([\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+)\\s*\\))\n  )\n",
+                "captures": {
+                  "1": {
+                    "name": "keyword.other.safety.$1.haskell"
+                  },
+                  "2": {
+                    "name": "entity.name.foreign.haskell",
+                    "patterns": [
+                      {
+                        "include": "#string_literal"
+                      }
+                    ]
+                  },
+                  "3": {
+                    "name": "entity.name.function.haskell"
+                  },
+                  "4": {
+                    "name": "entity.name.function.infix.haskell"
+                  }
+                }
+              },
+              {
+                "match": "(?x)\n  \\b(?<!')(safe|unsafe|interruptible)\\b(?!')\n  \\s*\n  (\"(?:\\\\\"|[^\"])*\")?\n  \\s*$\n",
+                "captures": {
+                  "1": {
+                    "name": "keyword.other.safety.$1.haskell"
+                  },
+                  "2": {
+                    "name": "entity.name.foreign.haskell",
+                    "patterns": [
+                      {
+                        "include": "#string_literal"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "match": "(?x)\n  \"(?:\\\\\"|[^\"])*\"",
+                "captures": {
+                  "0": {
+                    "name": "entity.name.foreign.haskell",
+                    "patterns": [
+                      {
+                        "include": "#string_literal"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "match": "(?x)\n   (?:\\b(?<!'')([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\\b(?!'))\n  |(?:(\\()\\s*(?!--+\\))([\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+)\\s*(\\)))\n",
+                "captures": {
+                  "1": {
+                    "name": "entity.name.function.haskell"
+                  },
+                  "2": {
+                    "name": "punctuation.paren.haskell"
+                  },
+                  "3": {
+                    "name": "entity.name.function.infix.haskell"
+                  },
+                  "4": {
+                    "name": "punctuation.paren.haskell"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "include": "#double_colon"
+          },
+          {
+            "include": "#type_signature"
+          }
+        ]
+      },
+      "inline_phase": {
+        "begin": "\\[",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.bracket.haskell"
+          }
+        },
+        "end": "\\]",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.bracket.haskell"
+          }
+        },
+        "name": "meta.inlining-phase.haskell",
+        "patterns": [
+          {
+            "match": "~",
+            "name": "punctuation.tilde.haskell"
+          },
+          {
+            "include": "#integer_literals"
+          },
+          {
+            "match": "\\w*",
+            "name": "invalid"
+          }
+        ]
+      },
+      "quasi_quote": {
+        "patterns": [
+          {
+            "begin": "(?x)\n  (\\[)\n  (e|d|p)?\n  (\\|(?:\\|(?!\\]))?)",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.quasi-quotation.begin.haskell"
+              },
+              "2": {
+                "name": "entity.name.quasi-quoter.haskell"
+              },
+              "3": {
+                "name": "keyword.operator.quasi-quotation.begin.haskell"
+              }
+            },
+            "end": "\\3\\]",
+            "endCaptures": {
+              "0": {
+                "name": "keyword.operator.quasi-quotation.end.haskell"
+              }
+            },
+            "name": "meta.quasi-quotation.haskell",
+            "patterns": [
+              {
+                "include": "$self"
+              }
+            ]
+          },
+          {
+            "begin": "(?x)\n  (\\[)\n  (t)\n  (\\|(?:\\|(?!\\]))?)",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.quasi-quotation.begin.haskell"
+              },
+              "2": {
+                "name": "entity.name.quasi-quoter.haskell"
+              },
+              "3": {
+                "name": "keyword.operator.quasi-quotation.begin.haskell"
+              }
+            },
+            "end": "\\3\\]",
+            "endCaptures": {
+              "0": {
+                "name": "keyword.operator.quasi-quotation.end.haskell"
+              }
+            },
+            "name": "meta.quasi-quotation.haskell",
+            "patterns": [
+              {
+                "include": "#type_signature"
+              }
+            ]
+          },
+          {
+            "begin": "(?x)\n  (\\[)\n  (?:(\\$\\$)|(\\$))?\n  (?!'\\|')                                             # Don't parse ['|'...] as a quasi quotation\n  ((?:[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*\\.)*) # Optional qualifier\n  ((?:[^\\s\\p{S}\\p{P}]|['_])*)                          # Quasi-quoter\n  (\\|)",
+            "beginCaptures": {
+              "1": {
+                "name": "keyword.operator.quasi-quotation.begin.haskell"
+              },
+              "2": {
+                "name": "keyword.operator.prefix.double-dollar.haskell"
+              },
+              "3": {
+                "name": "keyword.operator.prefix.dollar.haskell"
+              },
+              "4": {
+                "name": "entity.name.namespace.haskell"
+              },
+              "5": {
+                "name": "entity.name.quasi-quoter.haskell"
+              },
+              "6": {
+                "name": "keyword.operator.quasi-quotation.begin.haskell"
+              }
+            },
+            "end": "\\|\\]",
+            "endCaptures": {
+              "0": {
+                "name": "keyword.operator.quasi-quotation.end.haskell"
+              }
+            },
+            "name": "meta.quasi-quotation.haskell meta.embedded.block.$5"
+          }
+        ]
+      }
+    },
+    "scopeName": "source.haskell",
+    "uuid": "5C034675-1F6D-497E-8073-369D37E2FD7D"
+  }
+  

--- a/playground/src/components/Editor.vue
+++ b/playground/src/components/Editor.vue
@@ -409,13 +409,13 @@ import { callKuber,getPolicyIdOfScriptFromKuber,listProviders, signTx, submitTx 
             <div class="mb-5 font-semibold text-gray-500">Enter Address</div>
             
             <input
-              class="flex w-full input border border-gray-300 focus:border-gray-400"
+              class="flex w-full normal-input border border-gray-300 focus:border-gray-400"
               type="text"
               :value="address"
               @input="onAddressInput"
             />
             <div class="mt-4 mb-4" v-if="keyHash != ''">
-              <div class="text-gray-500 text-sm mb-1 mt-3">PublicKey Hash</div>
+              <div class="text-gray-500 text-sm mb-1 mt-3">{{paymentCredText}}</div>
               <div>
                 <button class="flex" @click="performKeyHashCopy">
                   <div class="text-gray-700">{{ keyHash }}</div>
@@ -436,7 +436,7 @@ import { callKuber,getPolicyIdOfScriptFromKuber,listProviders, signTx, submitTx 
                 </button>
               </div>
 
-              <div class="text-gray-500 text-sm mb-1 mt-5">StakeKey Hash</div>
+              <div class="text-gray-500 text-sm mb-1 mt-5">{{stakeCredText}}</div>
               <div>
                 <button class="flex" @click="copyToClipboard(stakeKeyHash)">
                   <div class="text-gray-700">{{ stakeKeyHash }}</div> 
@@ -467,19 +467,41 @@ import { callKuber,getPolicyIdOfScriptFromKuber,listProviders, signTx, submitTx 
             class="flex flex-col w-full items-start"
             v-if="switchAddress == true"
           >
-            
-            <div class="mb-5 font-semibold text-gray-500">PublicKey Hash</div>
-            <input
-              class="flex w-full input border border-gray-300 focus:border-gray-400"
-              type="text"
-              v-model="pubkeyinput"
-            />
-            <div class="mb-5 font-semibold text-gray-500">StakeKey Hash</div>
-            <input
-              class="0 input border border-gray-300 focus:border-gray-400"
-              type="text"
-              v-model="stakekeyinput"
-            />
+            <select id="currency" v-model="network" name="network" class="h-full rounded-md border-transparent bg-transparent py-0 pl-2 pr-1 text-gray-500 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                <option>Testnet</option>
+                <option>Mainnet</option>
+                      
+            </select>
+            <div class="mt-5 w-full">
+              <label for="price" class="block font-semibold text-gray-500">Payment Credential</label>
+              <div class="relative mt-1 rounded-md shadow-sm">
+                <input class="block w-5/6 input border rounded border-gray-300 pl-7 pr-12 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" type="text" v-model="pubkeyinput"/>
+                <!-- <input type="text" name="price" id="price" class="block w-5/6 rounded-md border-gray-300 pl-7 pr-12 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" placeholder="0.00"> -->
+                <div class="absolute inset-y-0 right-0 flex items-center">
+                  <label for="hashtype" class="sr-only">Hash Type</label>
+                  <select id="hashtype" v-model="scriptPubKey" name="currency" class="h-full rounded-md border-transparent bg-transparent py-0 pl-2 pr-1 text-gray-500 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                    <option>Script Hash</option>
+                    <option>Key Hash</option>
+                    
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div class="mt-5 w-full">
+              <label for="price" class="block font-semibold text-gray-500">Stake Credential</label>
+              <div class="relative mt-1 rounded-md shadow-sm">
+                <input class="block w-5/6 input border rounded border-gray-300 pl-7 pr-12 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" type="text" v-model="stakekeyinput"/>
+                <!-- <input type="text" name="price" id="price" class="block w-5/6 rounded-md border-gray-300 pl-7 pr-12 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" placeholder="0.00"> -->
+                <div class="absolute inset-y-0 right-0 flex items-center">
+                  <label for="currency" class="sr-only">Hash Type</label>
+                  <select id="currency" v-model="scriptStakeKey" name="currency" class="h-full rounded-md border-transparent bg-transparent py-0 pl-2 pr-1 text-gray-500 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                    <option>Script Hash</option>
+                    <option>Key Hash</option>
+                    
+                  </select>
+                </div>
+              </div>
+            </div>
             <div class="break-words mt-4 mb-4" v-if="generatedAddress != ''">
               <div class="text-gray-500 text-sm mb-1 mt-3">Address</div>
               <div class="">
@@ -502,7 +524,7 @@ import { callKuber,getPolicyIdOfScriptFromKuber,listProviders, signTx, submitTx 
                 </button>
               </div>
             </div>
-              <div class="mt-53">
+              <div class="mt-5">
                 <button @click="getAddressFromHashKeys(pubkeyinput, stakekeyinput )" class="button-old hover:bg-green-600">
                   Get Address
                 </button> 
@@ -835,6 +857,7 @@ import {
   Ed25519KeyHash,
   EnterpriseAddress,
   PointerAddress,
+  ScriptHash,
   StakeCredential
 } from "@emurgo/cardano-serialization-lib-asmjs";
 import { SchemaKuber } from "./schemas";
@@ -905,6 +928,11 @@ export default {
       networkSettingTab: NetworkSettingEnums.EditNetwork,
       kuberOutputs: [],
       pubkeyinput : "",
+      scriptPubKey:"Key Hash",
+      scriptStakeKey:"Key Hash",
+      network:"Testnet",
+      paymentCredText:"Payment Credential: PubKeyHash",
+      stakeCredText: "Stake Credential: PubKeyHash",
       stakekeyinput:"",
       generatedAddress:"",
       switchAddress:false,
@@ -1292,6 +1320,11 @@ export default {
         this.result = "";
       }
     },
+    // getScriptHashFromAddress(){
+    //   let addr = Address.from_bech32(this.address);
+    //   let scrHash = ScriptHash.from_bech32(this.address);
+    //   console.log(scrHash);
+    // },
     getKeyHash() {
       // TODO do this with serialization library and not by calling api
       let addr = Address.from_bech32(this.address);
@@ -1301,17 +1334,51 @@ export default {
       let keyHash: Ed25519KeyHash;
       let stakeKeyHash : any;
       if (addrBase) {
-        console.log("hashKind", addrBase.payment_cred().kind);
-        keyHash = addrBase.payment_cred().to_keyhash() ;
-        stakeKeyHash = addrBase.stake_cred().to_keyhash() || addrBase.stake_cred().to_scripthash() 
-      } else if (addrPointer) {
-        keyHash = addrPointer.payment_cred().to_keyhash();
-      } else if (addrEnterprise) {
-        keyHash = addrEnterprise.payment_cred().to_keyhash();
+        if(addrBase.payment_cred().kind() == 0){
+          keyHash = addrBase.payment_cred().to_keyhash() ;
+        }
+        else{
+          keyHash = addrBase.payment_cred().to_scripthash();
+          this.paymentCredText = "Payment Credential: Script Hash";
+        }
+        if(addrBase.stake_cred().kind() == 0){
+          stakeKeyHash = addrBase.stake_cred().to_keyhash();
+        }
+        else{
+          stakeKeyHash = addrBase.stake_cred().to_scripthash();
+          this.stakeCredText = "Stake Credential: Script Hash";
+        }
+        
+      } 
+      else if (addrPointer) {
+        if(addrPointer.payment_cred().kind() == 0){
+          keyHash = addrPointer.payment_cred().to_keyhash() ;
+          stakeKeyHash = "";
+        }
+        else{
+          keyHash = addrPointer.payment_cred().to_scripthash();
+          this.paymentCredText = "Payment Credential: Script Hash";
+          stakeKeyHash = "";
+        }
+        this.stakeCredText = "Stake Credential";
+      } 
+      else if (addrEnterprise) {
+        console.log("hashKind", addrEnterprise.payment_cred().kind());
+        if(addrEnterprise.payment_cred().kind() == 0){
+          keyHash = addrEnterprise.payment_cred().to_keyhash() ;
+        }
+        else{
+          keyHash = addrEnterprise.payment_cred().to_scripthash();
+          this.paymentCredText = "Payment Credential: Script Hash";
+        }
+        this.stakeCredText = "Stake Credential";
       }
       let keyHashHex = Buffer.from(keyHash.to_bytes()).toString("hex");
       if(stakeKeyHash){
         this.stakeKeyHash=Buffer.from(stakeKeyHash.to_bytes()).toString("hex");
+      }
+      else{
+        this.stakeKeyHash="";
       }
       this.keyHash = keyHashHex;
 
@@ -1322,22 +1389,35 @@ export default {
       //   });
     },
     getAddressFromHashKeys(pubkey, stakekey) {
-      const pubKey = StakeCredential.from_keyhash(Ed25519KeyHash.from_bytes(Buffer.from(pubkey, "hex")))
-      let network = 0;
-      if(this.activeApi.name=="Mainnet" ){
-        network = 1;
+      let pubKey;
+      if(this.scriptPubKey == "Key Hash"){
+        pubKey = StakeCredential.from_keyhash(Ed25519KeyHash.from_bytes(Buffer.from(pubkey, "hex")));
+      }
+      else if(this.scriptPubKey == "Script Hash"){
+        pubKey = StakeCredential.from_scripthash(ScriptHash.from_bytes(Buffer.from(pubkey, "hex")));  
       }
       let addr = "";
+      const network = this.network=="Testnet" ? 0 : 1;
       if(stakekey==''){
+        console.log("here ", network);
         const address= EnterpriseAddress.new(network,pubKey);
         addr = address.to_address().to_bech32();
+        
       }
       else if(stakekey!='' && pubkey!=''){
-        const stakeKey = StakeCredential.from_keyhash(Ed25519KeyHash.from_bytes(Buffer.from(stakekey, "hex")));
-        const address = BaseAddress.new(network, pubKey, stakeKey);
-        addr = address.to_address().to_bech32();
+        if(this.scriptStakeKey=="Key Hash"){
+          const stakeKey = StakeCredential.from_keyhash(Ed25519KeyHash.from_bytes(Buffer.from(stakekey, "hex")));
+          const address = BaseAddress.new(network, pubKey, stakeKey);
+          addr = address.to_address().to_bech32();
+        }
+        else{
+          const stakeKey = StakeCredential.from_scripthash(ScriptHash.from_hex(stakekey));
+          const address = BaseAddress.new(network, pubKey, stakeKey);
+          addr = address.to_address().to_bech32();
+        }
       }
       this.generatedAddress = addr;
+      console.log(addr);
     },
     getScriptPolicy() {
       // TODO do this with serialization library and not by calling api
@@ -1677,9 +1757,16 @@ export default {
 
 .input {
   height: 50px;
-  width: 100%;
+  width: 73%;
   padding: 5px;
   border-radius: 4px;
+}
+
+.normal-input{
+  height:50px;
+  width:100%;
+  padding:5px;
+  border-radius:4px;
 }
 
 .textarea {

--- a/playground/src/components/Editor.vue
+++ b/playground/src/components/Editor.vue
@@ -893,6 +893,7 @@ import {registerLanguages} from '../syntax_helpers/register';
 import {rehydrateRegexps} from '../syntax_helpers/configuration';
 import VsCodeDarkTheme from '../syntax_helpers/vs-dark-plus-theme';
 import { generate } from "@vue/compiler-core";
+import vsDarkPlusTheme from "../syntax_helpers/vs-dark-plus-theme";
 
 const notification = _notification.useNotificationStore();
 
@@ -1606,7 +1607,7 @@ export default {
         });
 
         const theme = {
-          base: "vs",
+          base: "vs-dark",
           inherit: true,
           rules: [
             {
@@ -1689,7 +1690,7 @@ export default {
           fetchGrammar,
           configurations: languages.map((language) => language.id),
           fetchConfiguration,
-          theme: VsCodeDarkTheme,
+          theme: vsDarkPlusTheme,
           onigLib,
           monaco,
         });
@@ -1702,9 +1703,11 @@ export default {
         this.$options.editor = monaco.editor.create(
           document.getElementById("monaco_editor"),
           {
+            language: "haskell",
             model: model,
+            
             minimap: { enabled: false },
-            theme: "myTheme",
+            theme: "vs-dark",
             automaticLayout: true,
           }
         );

--- a/playground/src/models/enums/DescriptionEnum.ts
+++ b/playground/src/models/enums/DescriptionEnum.ts
@@ -3,5 +3,5 @@ export enum KuberDiscriptionEnums {
   Inputs = "inputs",
   Outputs = "outputs",
   Mint = "mint",
-  MetaData = "metadata",
+  MetaData = "metadata",  
 }

--- a/playground/src/syntax_helpers/configuration.ts
+++ b/playground/src/syntax_helpers/configuration.ts
@@ -1,0 +1,66 @@
+import type * as monaco from 'monaco-editor';
+
+/**
+ * Fields that, if present in a LanguageConfiguration, must be a RegExp object
+ * rather than a string literal.
+ */
+const REGEXP_PROPERTIES = [
+  // indentation
+  'indentationRules.decreaseIndentPattern',
+  'indentationRules.increaseIndentPattern',
+  'indentationRules.indentNextLinePattern',
+  'indentationRules.unIndentedLinePattern',
+
+  // code folding
+  'folding.markers.start',
+  'folding.markers.end',
+
+  // language's "word definition"
+  'wordPattern',
+];
+
+/**
+ * Configuration data is read from JSON and JSONC files, which cannot contain
+ * regular expression literals. Although Monarch grammars will often accept
+ * either the source of a RegExp as a string OR a RegExp object, certain Monaco
+ * APIs accept only a RegExp object, so we must "rehydrate" those, as appropriate.
+ *
+ * It would probably save everyone a lot of trouble if we updated the APIs to
+ * accept a RegExp or a string literal. Possibly a small struct if flags need
+ * to be specified to the RegExp constructor.
+ */
+export function rehydrateRegexps(rawConfiguration: string): monaco.languages.LanguageConfiguration {
+  const out = JSON.parse(rawConfiguration);
+  for (const property of REGEXP_PROPERTIES) {
+    const value = getProp(out, property);
+    if (typeof value === 'string') {
+      setProp(out, property, new RegExp(value));
+    }
+  }
+  return out;
+}
+
+function getProp(obj: {string: any}, selector: string): any {
+  const components = selector.split('.');
+  // @ts-ignore
+  return components.reduce((acc, cur) => (acc != null ? acc[cur] : null), obj);
+}
+
+function setProp(obj: {string: any}, selector: string, value: RegExp): void {
+  const components = selector.split('.');
+  const indexToSet = components.length - 1;
+  components.reduce((acc, cur, index) => {
+    if (acc == null) {
+      return acc;
+    }
+
+    if (index === indexToSet) {
+      // @ts-ignore
+      acc[cur] = value;
+      return null;
+    } else {
+      // @ts-ignore
+      return acc[cur];
+    }
+  }, obj);
+}

--- a/playground/src/syntax_helpers/cssColors.ts
+++ b/playground/src/syntax_helpers/cssColors.ts
@@ -1,0 +1,11 @@
+export function generateTokensCSSForColorMap(colorMap) {
+    let rules = [];
+    for (let i = 1, len = colorMap.length; i < len; i++) {
+        let color = colorMap[i];
+        rules[i] = `.mtk${i} { color: ${color}; }`;
+    }
+    rules.push('.mtki { font-style: italic; }');
+    rules.push('.mtkb { font-weight: bold; }');
+    rules.push('.mtku { text-decoration: underline; text-underline-position: under; }');
+    return rules.join('\n');
+}

--- a/playground/src/syntax_helpers/index.ts
+++ b/playground/src/syntax_helpers/index.ts
@@ -1,0 +1,5 @@
+import {rehydrateRegexps} from './configuration';
+import {SimpleLanguageInfoProvider} from './providers';
+import {registerLanguages} from './register';
+
+export {SimpleLanguageInfoProvider, registerLanguages, rehydrateRegexps};

--- a/playground/src/syntax_helpers/providers.ts
+++ b/playground/src/syntax_helpers/providers.ts
@@ -1,0 +1,233 @@
+import type * as monaco from 'monaco-editor';
+type Monaco = typeof monaco;
+import type {IGrammar, IRawGrammar, IRawTheme, IOnigLib, StackElement} from 'vscode-textmate';
+import type {LanguageId, LanguageInfo} from './register';
+
+import {INITIAL, Registry, parseRawGrammar} from 'vscode-textmate';
+// @ts-ignore
+import {generateTokensCSSForColorMap} from './cssColors';
+// @ts-ignore
+import {TokenizationRegistry} from 'monaco-editor/esm/vs/editor/common/tokenizationRegistry';
+// @ts-ignore
+import {Color} from 'monaco-editor/esm/vs/base/common/color.js';
+
+/** String identifier for a "scope name" such as 'source.cpp' or 'source.java'. */
+export type ScopeName = string;
+
+export type TextMateGrammar = {
+  type: 'json' | 'plist';
+  grammar: string;
+};
+
+export type SimpleLanguageInfoProviderConfig = {
+  // Key is a ScopeName.
+  grammars: {[scopeName: string]: ScopeNameInfo};
+
+  fetchGrammar: (scopeName: ScopeName) => Promise<TextMateGrammar>;
+
+  configurations: LanguageId[];
+
+  fetchConfiguration: (language: LanguageId) => Promise<monaco.languages.LanguageConfiguration>;
+
+  // This must be available synchronously to the SimpleLanguageInfoProvider
+  // constructor, so the user is responsible for fetching the theme data rather
+  // than SimpleLanguageInfoProvider.
+  theme: IRawTheme;
+
+  onigLib: Promise<IOnigLib>;
+  monaco: Monaco;
+};
+
+export interface ScopeNameInfo {
+  /**
+   * If set, this is the id of an ILanguageExtensionPoint. This establishes the
+   * mapping from a MonacoLanguage to a TextMate grammar.
+   */
+  language?: LanguageId;
+
+  /**
+   * Scopes that are injected *into* this scope. For example, the
+   * `text.html.markdown` scope likely has a number of injections to support
+   * fenced code blocks.
+   */
+  injections?: ScopeName[];
+}
+
+/**
+ * Basic provider to implement the fetchLanguageInfo() function needed to
+ * power registerLanguages(). It is designed to fetch all resources
+ * asynchronously based on a simple layout of static resources on the server.
+ */
+export class SimpleLanguageInfoProvider {
+  private monaco: Monaco;
+  private registry: Registry;
+  private tokensProviderCache: TokensProviderCache;
+
+  constructor(private config: SimpleLanguageInfoProviderConfig) {
+    const {grammars, fetchGrammar, theme, onigLib, monaco} = config;
+    this.monaco = monaco;
+
+    this.registry = new Registry({
+      onigLib,
+
+      async loadGrammar(scopeName: ScopeName): Promise<IRawGrammar | null> {
+        const scopeNameInfo = grammars[scopeName];
+        if (scopeNameInfo == null) {
+          return null;
+        }
+
+        const {type, grammar} = await fetchGrammar(scopeName);
+        // If this is a JSON grammar, filePath must be specified with a `.json`
+        // file extension or else parseRawGrammar() will assume it is a PLIST
+        // grammar.
+        return parseRawGrammar(grammar, `example.${type}`);
+      },
+
+      /**
+       * For the given scope, returns a list of additional grammars that should be
+       * "injected into" it (i.e., a list of grammars that want to extend the
+       * specified `scopeName`). The most common example is other grammars that
+       * want to "inject themselves" into the `text.html.markdown` scope so they
+       * can be used with fenced code blocks.
+       *
+       * In the manifest of a VS Code extension, a grammar signals that it wants
+       * to do this via the "injectTo" property:
+       * https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#injection-grammars
+       */
+      getInjections(scopeName: ScopeName): string[] | undefined {
+        const grammar = grammars[scopeName];
+        return grammar ? grammar.injections : undefined;
+      },
+
+      // Note that nothing will display without the theme!
+      theme,
+    });
+
+    this.tokensProviderCache = new TokensProviderCache(this.registry);
+  }
+
+  /**
+   * Be sure this is done after Monaco injects its default styles so that the
+   * injected CSS overrides the defaults.
+   */
+  injectCSS() {
+    const cssColors = this.registry.getColorMap();
+    const colorMap = cssColors.map(Color.Format.CSS.parseHex);
+    // This is needed to ensure the minimap gets the right colors.
+    TokenizationRegistry.setColorMap(colorMap);
+    const css = generateTokensCSSForColorMap(colorMap);
+    const style = createStyleElementForColorsCSS();
+    style.innerHTML = css;
+  }
+
+  async fetchLanguageInfo(language: LanguageId): Promise<LanguageInfo> {
+    const [tokensProvider, configuration] = await Promise.all([
+      this.getTokensProviderForLanguage(language),
+      this.config.fetchConfiguration(language),
+    ]);
+    return {tokensProvider, configuration};
+  }
+
+  private getTokensProviderForLanguage(
+    language: string,
+  ): Promise<monaco.languages.EncodedTokensProvider | null> {
+    const scopeName = this.getScopeNameForLanguage(language);
+    if (scopeName == null) {
+      return Promise.resolve(null);
+    }
+
+    const encodedLanguageId = this.monaco.languages.getEncodedLanguageId(language);
+    // Ensure the result of createEncodedTokensProvider() is resolved before
+    // setting the language configuration.
+    return this.tokensProviderCache.createEncodedTokensProvider(scopeName, encodedLanguageId);
+  }
+
+  private getScopeNameForLanguage(language: string): string | null {
+    for (const [scopeName, grammar] of Object.entries(this.config.grammars)) {
+      if (grammar.language === language) {
+        return scopeName;
+      }
+    }
+    return null;
+  }
+}
+
+class TokensProviderCache {
+  private scopeNameToGrammar: Map<string, Promise<IGrammar>> = new Map();
+
+  constructor(private registry: Registry) {}
+
+  async createEncodedTokensProvider(
+    scopeName: string,
+    encodedLanguageId: number,
+  ): Promise<monaco.languages.EncodedTokensProvider> {
+    const grammar = await this.getGrammar(scopeName, encodedLanguageId);
+
+    return {
+      getInitialState() {
+        return INITIAL;
+      },
+
+      tokenizeEncoded(
+        line: string,
+        state: monaco.languages.IState,
+      ): monaco.languages.IEncodedLineTokens {
+        const tokenizeLineResult2 = grammar.tokenizeLine2(line, state as StackElement);
+        const {tokens, ruleStack: endState} = tokenizeLineResult2;
+        return {tokens, endState};
+      },
+    };
+  }
+
+  getGrammar(scopeName: string, encodedLanguageId: number): Promise<IGrammar> {
+    const grammar = this.scopeNameToGrammar.get(scopeName);
+    if (grammar != null) {
+      return grammar;
+    }
+
+    // This is defined in vscode-textmate and has optional embeddedLanguages
+    // and tokenTypes fields that might be useful/necessary to take advantage of
+    // at some point.
+    const grammarConfiguration = {};
+    // We use loadGrammarWithConfiguration() rather than loadGrammar() because
+    // we discovered that if the numeric LanguageId is not specified, then it
+    // does not get encoded in the TokenMetadata.
+    //
+    // Failure to do so means that the LanguageId cannot be read back later,
+    // which can cause other Monaco features, such as "Toggle Line Comment",
+    // to fail.
+    const promise = this.registry
+      .loadGrammarWithConfiguration(scopeName, encodedLanguageId, grammarConfiguration)
+      .then((grammar: IGrammar | null) => {
+        if (grammar) {
+          return grammar;
+        } else {
+          throw Error(`failed to load grammar for ${scopeName}`);
+        }
+      });
+    this.scopeNameToGrammar.set(scopeName, promise);
+    return promise;
+  }
+}
+
+function createStyleElementForColorsCSS(): HTMLStyleElement {
+  // We want to ensure that our <style> element appears after Monaco's so that
+  // we can override some styles it inserted for the default theme.
+  const style = document.createElement('style');
+
+  // We expect the styles we need to override to be in an element with the class
+  // name 'monaco-colors' based on:
+  // https://github.com/microsoft/vscode/blob/f78d84606cd16d75549c82c68888de91d8bdec9f/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts#L206-L214
+  const monacoColors = document.getElementsByClassName('monaco-colors')[0];
+  if (monacoColors) {
+    monacoColors.parentElement?.insertBefore(style, monacoColors.nextSibling);
+  } else {
+    // Though if we cannot find it, just append to <head>.
+    let {head} = document;
+    if (head == null) {
+      head = document.getElementsByTagName('head')[0];
+    }
+    head?.appendChild(style);
+  }
+  return style;
+}

--- a/playground/src/syntax_helpers/providers.ts
+++ b/playground/src/syntax_helpers/providers.ts
@@ -114,7 +114,8 @@ export class SimpleLanguageInfoProvider {
     const cssColors = this.registry.getColorMap();
     const colorMap = cssColors.map(Color.Format.CSS.parseHex);
     // This is needed to ensure the minimap gets the right colors.
-    TokenizationRegistry.setColorMap(colorMap);
+    const tokenization = new TokenizationRegistry()
+    tokenization.setColorMap(colorMap);
     const css = generateTokensCSSForColorMap(colorMap);
     const style = createStyleElementForColorsCSS();
     style.innerHTML = css;

--- a/playground/src/syntax_helpers/register.ts
+++ b/playground/src/syntax_helpers/register.ts
@@ -1,0 +1,44 @@
+import type * as monaco from 'monaco-editor';
+type Monaco = typeof monaco;
+
+/** String identifier like 'cpp' or 'java'. */
+export type LanguageId = string;
+
+export type LanguageInfo = {
+  tokensProvider: monaco.languages.EncodedTokensProvider | null;
+  configuration: monaco.languages.LanguageConfiguration | null;
+};
+
+/**
+ * This function needs to be called before monaco.editor.create().
+ *
+ * @param languages the set of languages Monaco must know about up front.
+ * @param fetchLanguageInfo fetches full language configuration on demand.
+ * @param monaco instance of Monaco on which to register languages information.
+ */
+export function registerLanguages(
+  languages: monaco.languages.ILanguageExtensionPoint[],
+  fetchLanguageInfo: (language: LanguageId) => Promise<LanguageInfo>,
+  monaco: Monaco,
+) {
+  // We have to register all of the languages with Monaco synchronously before
+  // we can configure them.
+  for (const extensionPoint of languages) {
+    // Recall that the id is a short name like 'cpp' or 'java'.
+    const {id: languageId} = extensionPoint;
+    monaco.languages.register(extensionPoint);
+
+    // Lazy-load the tokens provider and configuration data.
+    monaco.languages.onLanguage(languageId, async () => {
+      const {tokensProvider, configuration} = await fetchLanguageInfo(languageId);
+
+      if (tokensProvider != null) {
+        monaco.languages.setTokensProvider(languageId, tokensProvider);
+      }
+
+      if (configuration != null) {
+        monaco.languages.setLanguageConfiguration(languageId, configuration);
+      }
+    });
+  }
+}

--- a/playground/src/syntax_helpers/vs-dark-plus-theme.ts
+++ b/playground/src/syntax_helpers/vs-dark-plus-theme.ts
@@ -1,0 +1,530 @@
+// Theme data derived from:
+// https://github.com/microsoft/vscode/raw/a716714a88891cad69c0753fb95923870df295f5/extensions/theme-defaults/themes/dark_plus.json
+
+// This satisfies the contract of IRawTheme as defined in vscode-textmate.
+export default {
+  name: 'Dark+ (default dark)',
+  settings: [
+    {
+      settings: {
+        foreground: '#D4D4D4',
+        background: '#1E1E1E',
+      },
+    },
+    {
+      name: 'Function declarations',
+      scope: [
+        'entity.name.function',
+        'support.function',
+        'support.constant.handlebars',
+        'source.powershell variable.other.member',
+        'entity.name.operator.custom-literal',
+      ],
+      settings: {
+        foreground: '#DCDCAA',
+      },
+    },
+    {
+      name: 'Types declaration and references',
+      scope: [
+        'meta.return-type',
+        'support.class',
+        'support.type',
+        'entity.name.type',
+        'entity.name.namespace',
+        'entity.other.attribute',
+        'entity.name.scope-resolution',
+        'entity.name.class',
+        'storage.type.numeric.go',
+        'storage.type.byte.go',
+        'storage.type.boolean.go',
+        'storage.type.string.go',
+        'storage.type.uintptr.go',
+        'storage.type.error.go',
+        'storage.type.rune.go',
+        'storage.type.cs',
+        'storage.type.generic.cs',
+        'storage.type.modifier.cs',
+        'storage.type.variable.cs',
+        'storage.type.annotation.java',
+        'storage.type.generic.java',
+        'storage.type.java',
+        'storage.type.object.array.java',
+        'storage.type.primitive.array.java',
+        'storage.type.primitive.java',
+        'storage.type.token.java',
+        'storage.type.groovy',
+        'storage.type.annotation.groovy',
+        'storage.type.parameters.groovy',
+        'storage.type.generic.groovy',
+        'storage.type.object.array.groovy',
+        'storage.type.primitive.array.groovy',
+        'storage.type.primitive.groovy',
+      ],
+      settings: {
+        foreground: '#4EC9B0',
+      },
+    },
+    {
+      name: 'Types declaration and references, TS grammar specific',
+      scope: [
+        'meta.type.cast.expr',
+        'meta.type.new.expr',
+        'support.constant.math',
+        'support.constant.dom',
+        'support.constant.json',
+        'entity.other.inherited-class',
+      ],
+      settings: {
+        foreground: '#4EC9B0',
+      },
+    },
+    {
+      name: 'Control flow / Special keywords',
+      scope: [
+        'keyword.control',
+        'source.cpp keyword.operator.new',
+        'keyword.operator.delete',
+        'keyword.other.using',
+        'keyword.other.operator',
+        'entity.name.operator',
+      ],
+      settings: {
+        foreground: '#C586C0',
+      },
+    },
+    {
+      name: 'Variable and parameter name',
+      scope: [
+        'variable',
+        'meta.definition.variable.name',
+        'support.variable',
+        'entity.name.variable',
+      ],
+      settings: {
+        foreground: '#9CDCFE',
+      },
+    },
+    {
+      name: 'Constants and enums',
+      scope: ['variable.other.constant', 'variable.other.enummember'],
+      settings: {
+        foreground: '#51B6C4',
+      },
+    },
+    {
+      name: 'Object keys, TS grammar specific',
+      scope: 'meta.object-literal.key',
+      settings: {
+        foreground: '#9CDCFE',
+      },
+    },
+    {
+      name: 'CSS property value',
+      scope: [
+        'support.constant.property-value',
+        'support.constant.font-name',
+        'support.constant.media-type',
+        'support.constant.media',
+        'constant.other.color.rgb-value',
+        'constant.other.rgb-value',
+        'support.constant.color',
+      ],
+      settings: {
+        foreground: '#CE9178',
+      },
+    },
+    {
+      name: 'Regular expression groups',
+      scope: [
+        'punctuation.definition.group.regexp',
+        'punctuation.definition.group.assertion.regexp',
+        'punctuation.definition.character-class.regexp',
+        'punctuation.character.set.begin.regexp',
+        'punctuation.character.set.end.regexp',
+        'keyword.operator.negation.regexp',
+        'support.other.parenthesis.regexp',
+      ],
+      settings: {
+        foreground: '#CE9178',
+      },
+    },
+    {
+      scope: [
+        'constant.character.character-class.regexp',
+        'constant.other.character-class.set.regexp',
+        'constant.other.character-class.regexp',
+        'constant.character.set.regexp',
+      ],
+      settings: {
+        foreground: '#d16969',
+      },
+    },
+    {
+      scope: ['keyword.operator.or.regexp', 'keyword.control.anchor.regexp'],
+      settings: {
+        foreground: '#DCDCAA',
+      },
+    },
+    {
+      scope: 'keyword.operator.quantifier.regexp',
+      settings: {
+        foreground: '#d7ba7d',
+      },
+    },
+    {
+      scope: 'constant.character',
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'constant.character.escape',
+      settings: {
+        foreground: '#d7ba7d',
+      },
+    },
+    {
+      scope: 'entity.name.label',
+      settings: {
+        foreground: '#C8C8C8',
+      },
+    },
+    {
+      scope: ['meta.embedded', 'source.groovy.embedded'],
+      settings: {
+        foreground: '#D4D4D4',
+      },
+    },
+    {
+      scope: 'emphasis',
+      settings: {
+        fontStyle: 'italic',
+      },
+    },
+    {
+      scope: 'strong',
+      settings: {
+        fontStyle: 'bold',
+      },
+    },
+    {
+      scope: 'header',
+      settings: {
+        foreground: '#000080',
+      },
+    },
+    {
+      scope: 'comment',
+      settings: {
+        foreground: '#6A9955',
+      },
+    },
+    {
+      scope: 'constant.language',
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: [
+        'constant.numeric',
+        'entity.name.operator.custom-literal.number',
+        'keyword.operator.plus.exponent',
+        'keyword.operator.minus.exponent',
+      ],
+      settings: {
+        foreground: '#b5cea8',
+      },
+    },
+    {
+      scope: 'constant.regexp',
+      settings: {
+        foreground: '#646695',
+      },
+    },
+    {
+      scope: 'entity.name.tag',
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'entity.name.tag.css',
+      settings: {
+        foreground: '#d7ba7d',
+      },
+    },
+    {
+      scope: 'entity.other.attribute-name',
+      settings: {
+        foreground: '#9cdcfe',
+      },
+    },
+    {
+      scope: [
+        'entity.other.attribute-name.class.css',
+        'entity.other.attribute-name.class.mixin.css',
+        'entity.other.attribute-name.id.css',
+        'entity.other.attribute-name.parent-selector.css',
+        'entity.other.attribute-name.pseudo-class.css',
+        'entity.other.attribute-name.pseudo-element.css',
+        'source.css.less entity.other.attribute-name.id',
+        'entity.other.attribute-name.attribute.scss',
+        'entity.other.attribute-name.scss',
+      ],
+      settings: {
+        foreground: '#d7ba7d',
+      },
+    },
+    {
+      scope: 'invalid',
+      settings: {
+        foreground: '#f44747',
+      },
+    },
+    {
+      scope: 'markup.underline',
+      settings: {
+        fontStyle: 'underline',
+      },
+    },
+    {
+      scope: 'markup.bold',
+      settings: {
+        fontStyle: 'bold',
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'markup.heading',
+      settings: {
+        fontStyle: 'bold',
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'markup.italic',
+      settings: {
+        fontStyle: 'italic',
+      },
+    },
+    {
+      scope: 'markup.inserted',
+      settings: {
+        foreground: '#b5cea8',
+      },
+    },
+    {
+      scope: 'markup.deleted',
+      settings: {
+        foreground: '#ce9178',
+      },
+    },
+    {
+      scope: 'markup.changed',
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'punctuation.definition.quote.begin.markdown',
+      settings: {
+        foreground: '#6A9955',
+      },
+    },
+    {
+      scope: 'punctuation.definition.list.begin.markdown',
+      settings: {
+        foreground: '#6796e6',
+      },
+    },
+    {
+      scope: 'markup.inline.raw',
+      settings: {
+        foreground: '#ce9178',
+      },
+    },
+    {
+      name: 'brackets of XML/HTML tags',
+      scope: 'punctuation.definition.tag',
+      settings: {
+        foreground: '#808080',
+      },
+    },
+    {
+      scope: ['meta.preprocessor', 'entity.name.function.preprocessor'],
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'meta.preprocessor.string',
+      settings: {
+        foreground: '#ce9178',
+      },
+    },
+    {
+      scope: 'meta.preprocessor.numeric',
+      settings: {
+        foreground: '#b5cea8',
+      },
+    },
+    {
+      scope: 'meta.structure.dictionary.key.python',
+      settings: {
+        foreground: '#9cdcfe',
+      },
+    },
+    {
+      scope: 'meta.diff.header',
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'storage',
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'storage.type',
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: ['storage.modifier', 'keyword.operator.noexcept'],
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: ['string', 'entity.name.operator.custom-literal.string', 'meta.embedded.assembly'],
+      settings: {
+        foreground: '#ce9178',
+      },
+    },
+    {
+      scope: 'string.tag',
+      settings: {
+        foreground: '#ce9178',
+      },
+    },
+    {
+      scope: 'string.value',
+      settings: {
+        foreground: '#ce9178',
+      },
+    },
+    {
+      scope: 'string.regexp',
+      settings: {
+        foreground: '#d16969',
+      },
+    },
+    {
+      name: 'String interpolation',
+      scope: [
+        'punctuation.definition.template-expression.begin',
+        'punctuation.definition.template-expression.end',
+        'punctuation.section.embedded',
+      ],
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      name: 'Reset JavaScript string interpolation expression',
+      scope: 'meta.template.expression',
+      settings: {
+        foreground: '#d4d4d4',
+      },
+    },
+    {
+      scope: [
+        'support.type.vendored.property-name',
+        'support.type.property-name',
+        'variable.css',
+        'variable.scss',
+        'variable.other.less',
+        'source.coffee.embedded',
+      ],
+      settings: {
+        foreground: '#9cdcfe',
+      },
+    },
+    {
+      scope: 'keyword',
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'keyword.operator',
+      settings: {
+        foreground: '#d4d4d4',
+      },
+    },
+    {
+      scope: [
+        'keyword.operator.new',
+        'keyword.operator.expression',
+        'keyword.operator.cast',
+        'keyword.operator.sizeof',
+        'keyword.operator.alignof',
+        'keyword.operator.typeid',
+        'keyword.operator.alignas',
+        'keyword.operator.instanceof',
+        'keyword.operator.logical.python',
+        'keyword.operator.wordlike',
+      ],
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'keyword.other.unit',
+      settings: {
+        foreground: '#b5cea8',
+      },
+    },
+    {
+      scope: ['punctuation.section.embedded.begin.php', 'punctuation.section.embedded.end.php'],
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+    {
+      scope: 'support.function.git-rebase',
+      settings: {
+        foreground: '#9cdcfe',
+      },
+    },
+    {
+      scope: 'constant.sha.git-rebase',
+      settings: {
+        foreground: '#b5cea8',
+      },
+    },
+    {
+      name: 'coloring of the Java import and package identifiers',
+      scope: [
+        'storage.modifier.import.java',
+        'variable.language.wildcard.java',
+        'storage.modifier.package.java',
+      ],
+      settings: {
+        foreground: '#d4d4d4',
+      },
+    },
+    {
+      name: 'this.self',
+      scope: 'variable.language',
+      settings: {
+        foreground: '#569cd6',
+      },
+    },
+  ],
+};

--- a/playground/src/syntax_helpers/vs-dark-plus-theme.ts
+++ b/playground/src/syntax_helpers/vs-dark-plus-theme.ts
@@ -7,8 +7,8 @@ export default {
   settings: [
     {
       settings: {
-        foreground: '#D4D4D4',
-        background: '#1E1E1E',
+        foreground: '#14D4D4',
+        background: '#b2c8c5',
       },
     },
     {


### PR DESCRIPTION
This pull request adds syntax-highlighting support to this online Haskell IDE. Monaco only supports Monarch but textmate is more popular grammar and conversion from one to another isn't possible. However with wasm, syntax highlighting was possible without needing to convert to monarch manually.